### PR TITLE
fix(release): align tag triggers and workflow naming

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -3,7 +3,7 @@ name: Release Tauri Linux
 on:
   push:
     tags:
-      - "*-tauri-next"
+      - "v*"
 
 jobs:
   build-and-release-linux:

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -3,7 +3,9 @@ name: Release Tauri Linux
 on:
   push:
     tags:
-      - "v*"
+      - "*.*.*"
+      - "*.*.*-beta.*"
+      - "*.*.*-rc.*"
 
 jobs:
   build-and-release-linux:

--- a/.github/workflows/release-mac.yml
+++ b/.github/workflows/release-mac.yml
@@ -3,7 +3,7 @@ name: Release Tauri macOS
 on:
   push:
     tags:
-      - "*-tauri-next"
+      - "v*"
 
 jobs:
   build-and-release-macos:

--- a/.github/workflows/release-mac.yml
+++ b/.github/workflows/release-mac.yml
@@ -3,7 +3,9 @@ name: Release Tauri macOS
 on:
   push:
     tags:
-      - "v*"
+      - "*.*.*"
+      - "*.*.*-beta.*"
+      - "*.*.*-rc.*"
 
 jobs:
   build-and-release-macos:

--- a/.github/workflows/release-win.yml
+++ b/.github/workflows/release-win.yml
@@ -3,7 +3,9 @@ name: Release Tauri Windows
 on:
   push:
     tags:
-      - "v*"
+      - "*.*.*"
+      - "*.*.*-beta.*"
+      - "*.*.*-rc.*"
 
 jobs:
   build-and-release:

--- a/.github/workflows/release-win.yml
+++ b/.github/workflows/release-win.yml
@@ -3,7 +3,7 @@ name: Release Tauri Windows
 on:
   push:
     tags:
-      - "*-tauri-next"
+      - "v*"
 
 jobs:
   build-and-release:


### PR DESCRIPTION
Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)

## Issues
<!-- Strongly recommended: link a related issue here when available -->
Fixes #109

## Proposed changes
This hotfix updates the release workflow trigger to match the new version/tag convention (X.Y.Z) instead of the old *-tauri-next pattern.

Applicable version/tag
```
- "*.*.*"
- "*.*.*-beta.*"
- "*.*.*-rc.*"
```

## Checklist
- [x] I consent that this change becomes part of Tabst under its current or any future open source license
- [x] Changes are implemented
- [ ] New tests were added <!-- Strongly recommended. If no tests were added, explain why. -->

## Further details
- [ ] This is a breaking change
- [x] This change will require update of the documentation/website
