### PR TITLE
fix(updater): align manifest endpoints with release flow

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -49,6 +49,7 @@ AlphaTex 编辑器实现文档。
 | 文档 | 内容 |
 |------|------|
 | [AUTO_UPDATE.md](./ops/AUTO_UPDATE.md) | 自动更新实现（需与当前 Tauri updater 流程对照审阅） |
+| [TAURI_AUTO_UPDATE.md](./ops/TAURI_AUTO_UPDATE.md) | 当前 Tauri 自动更新发布/草稿/发布后校验流程 |
 | [REFACTORING.md](./ops/REFACTORING.md) | Effect-TS 重构总结 |
 | [SECURITY.md](./ops/SECURITY.md) | 安全审计记录 |
 | [TAURI_MIGRATION_STATUS.md](./TAURI_MIGRATION_STATUS.md) | Tauri 迁移当前进度、已完成项、待办与协作说明 |

--- a/docs/dev/ops/TAURI_AUTO_UPDATE.md
+++ b/docs/dev/ops/TAURI_AUTO_UPDATE.md
@@ -1,0 +1,54 @@
+# Tauri Auto Update Operations
+
+## Current release/update policy
+
+Tabst now uses the Tauri updater on desktop platforms.
+
+### Release creation flow
+
+1. Push a release tag using the semver scheme without a `v` prefix:
+   - stable: `0.6.8`
+   - beta: `0.6.8-beta.1`
+   - rc: `0.6.8-rc.1`
+2. The Windows, macOS, and Linux release workflows run in parallel.
+3. Each workflow builds platform artifacts and uploads them to the **same GitHub draft release**.
+4. After all platform assets are present, a maintainer manually publishes the draft release.
+
+### Why draft release is required
+
+The three platform workflows all call `softprops/action-gh-release` independently.
+If the first workflow publishes the release immediately, later workflows can fail to add their platform assets because the published release is treated as immutable in the current GitHub release flow.
+
+Using `draft: true` allows all three workflows to keep uploading assets to the same release until the maintainer confirms that the release is complete.
+
+## Important updater behavior
+
+### Updater checks do **not** work against draft releases
+
+The current updater endpoints use GitHub `releases/latest/download/...` URLs:
+
+- `latest-{{target}}-{{arch}}-{{bundle_type}}.json`
+- `latest-{{target}}-{{arch}}.json`
+
+GitHub does not expose draft releases through the `latest` download endpoint.
+That means updater checks on macOS, Windows, and Linux are expected to fail until the draft release is manually published.
+
+This is intentional with the current workflow design.
+
+## Manifest naming contract
+
+The generated updater manifests use the Tauri platform-and-architecture naming scheme:
+
+- macOS Apple Silicon: `latest-darwin-aarch64-app.json`
+- Windows x64: `latest-windows-x86_64-nsis.json`, `latest-windows-x86_64-msi.json`, `latest-windows-x86_64.json`
+- Linux x64: `latest-linux-x86_64-appimage.json`, `latest-linux-x86_64-deb.json`, `latest-linux-x86_64-rpm.json`, `latest-linux-x86_64.json`
+
+The updater endpoints in `src-tauri/tauri.conf.json` must stay aligned with that scheme.
+
+## Maintainer checklist
+
+- [ ] Push a semver tag without `v`
+- [ ] Wait for Windows/macOS/Linux release workflows to finish
+- [ ] Confirm the draft release contains all expected bundles, signatures, and updater JSON files
+- [ ] Publish the draft release manually
+- [ ] Only then test in-app updater checks on packaged builds

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -67,8 +67,8 @@
 	"plugins": {
 		"updater": {
 			"endpoints": [
-				"https://github.com/LIUBINfighter/Tabst.app/releases/latest/download/latest-{{target}}-{{bundle_type}}.json",
-				"https://github.com/LIUBINfighter/Tabst.app/releases/latest/download/latest-{{target}}.json"
+				"https://github.com/LIUBINfighter/Tabst.app/releases/latest/download/latest-{{target}}-{{arch}}-{{bundle_type}}.json",
+				"https://github.com/LIUBINfighter/Tabst.app/releases/latest/download/latest-{{target}}-{{arch}}.json"
 			],
 			"pubkey": "__UPDATER_PUBLIC_KEY__",
 			"windows": {


### PR DESCRIPTION
## Issues
<!-- Strongly recommended: link a related issue here when available -->
Fixes #113 

## Proposed changes
<!-- Describe the proposed changes -->
换到tauri版本后总是无法更新，现在应该能正确识别正式发布的release的版本号


## Checklist
- [x] I consent that this change becomes part of Tabst under its current or any future open source license
- [x] Changes are implemented
- [ ] New tests were added <!-- Strongly recommended. If no tests were added, explain why. -->

## Further details
- [ ] This is a breaking change
- [x] This change will require update of the documentation/website
