### PR TITLE
Fix/issue 117 link handling

### DIFF
--- a/src-tauri/src/fs_commands.rs
+++ b/src-tauri/src/fs_commands.rs
@@ -12,6 +12,14 @@ use crate::{
     ReadFileBytesResponse, ReadFileResponse, SaveResult,
 };
 
+fn is_allowed_external_target(target: &str) -> bool {
+    let normalized = target.trim().to_ascii_lowercase();
+    normalized.starts_with("http://")
+        || normalized.starts_with("https://")
+        || normalized.starts_with("mailto:")
+        || normalized.starts_with("tel:")
+}
+
 #[tauri::command]
 pub(crate) fn open_file(extensions: Vec<String>) -> Option<FileResult> {
     let mut dialog = FileDialog::new();
@@ -451,6 +459,50 @@ pub(crate) fn reveal_in_folder(file_path: String) -> BasicResult {
             .unwrap_or_else(|| normalized_path.clone());
         Command::new("xdg-open")
             .arg(target)
+            .status()
+            .map_err(to_error)
+    };
+
+    match result {
+        Ok(status) if status.success() => BasicResult {
+            success: true,
+            error: None,
+        },
+        Ok(status) => BasicResult {
+            success: false,
+            error: Some(format!("command-exit-{}", status.code().unwrap_or(-1))),
+        },
+        Err(error) => BasicResult {
+            success: false,
+            error: Some(error),
+        },
+    }
+}
+
+#[tauri::command]
+pub(crate) fn open_external(target: String) -> BasicResult {
+    let normalized_target = target.trim().to_string();
+    if normalized_target.is_empty() || !is_allowed_external_target(&normalized_target) {
+        return BasicResult {
+            success: false,
+            error: Some("unsupported-external-target".to_string()),
+        };
+    }
+
+    let result = if cfg!(target_os = "macos") {
+        Command::new("open")
+            .arg(&normalized_target)
+            .status()
+            .map_err(to_error)
+    } else if cfg!(target_os = "windows") {
+        Command::new("rundll32")
+            .arg("url.dll,FileProtocolHandler")
+            .arg(&normalized_target)
+            .status()
+            .map_err(to_error)
+    } else {
+        Command::new("xdg-open")
+            .arg(&normalized_target)
             .status()
             .map_err(to_error)
     };

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,8 +7,9 @@ mod support;
 mod updater_commands;
 
 use fs_commands::{
-	create_file, create_folder, load_app_state, move_path, open_file, read_asset, read_file,
-	read_file_bytes, rename_file, reveal_in_folder, save_app_state, save_file, select_folder,
+	create_file, create_folder, load_app_state, move_path, open_external, open_file,
+	read_asset, read_file, read_file_bytes, rename_file, reveal_in_folder, save_app_state,
+	save_file, select_folder,
 };
 use git_commands::{
 	commit_git_changes, get_git_diff, get_git_status, stage_all_git_changes, stage_git_file,
@@ -40,6 +41,7 @@ pub fn run() {
 			rename_file,
 			move_path,
 			reveal_in_folder,
+			open_external,
 			read_asset,
 			read_file,
 			read_file_bytes,

--- a/src/renderer/components/Editor.tsx
+++ b/src/renderer/components/Editor.tsx
@@ -39,6 +39,7 @@ import Preview from "./Preview";
 import QuoteCard from "./QuoteCard";
 import TopBar from "./TopBar";
 import { TracksPanel, type TracksPanelProps } from "./TracksPanel";
+import { AppLink } from "./ui/app-link";
 import { Button } from "./ui/button";
 import IconButton from "./ui/icon-button";
 import {
@@ -670,10 +671,8 @@ export function Editor({
 			<div className="flex-1 flex items-center justify-center">
 				<div className="flex flex-col items-center gap-5 px-4 py-6 sm:gap-6">
 					{isWebRuntime ? (
-						<a
+						<AppLink
 							href="https://github.com/LIUBINfighter/Tabst.app"
-							target="_blank"
-							rel="noopener noreferrer"
 							className="w-[min(44rem,94vw)] rounded-2xl border border-primary/30 bg-gradient-to-br from-primary/10 via-card to-card p-4 shadow-sm transition-colors hover:border-primary/60 hover:bg-primary/5 sm:p-6"
 						>
 							<div className="mb-4 flex items-start justify-between gap-3">
@@ -694,7 +693,7 @@ export function Editor({
 							<span className="text-sm font-medium text-primary">
 								{t("common:webSandboxCardOpenRepo")}
 							</span>
-						</a>
+						</AppLink>
 					) : null}
 					<p className="text-sm text-muted-foreground">
 						{t("common:selectOrCreateFile")}

--- a/src/renderer/components/settings/AboutPage.tsx
+++ b/src/renderer/components/settings/AboutPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { TutorialRenderer } from "../tutorial/TutorialRenderer";
+import { AppLink } from "../ui/app-link";
 
 export function AboutPage() {
 	const { t } = useTranslation(["settings", "common"]);
@@ -60,14 +61,12 @@ export function AboutPage() {
 					<p className="text-xs text-muted-foreground">
 						{t("settings:aboutTagline2")}
 					</p>
-					<a
+					<AppLink
 						href="https://github.com/LIUBINfighter/Tabst.app"
-						target="_blank"
-						rel="noopener noreferrer"
 						className="text-xs text-primary hover:underline inline-block"
 					>
 						{t("settings:githubLink")}
-					</a>
+					</AppLink>
 				</div>
 			</section>
 
@@ -85,32 +84,26 @@ export function AboutPage() {
 						{t("settings:alphatabCaptionLine1")}
 					</p>
 					<p className="text-xs text-muted-foreground text-center">
-						<a
+						<AppLink
 							href="https://github.com/CoderLine/alphaTab"
-							target="_blank"
-							rel="noopener noreferrer"
 							className="text-xs text-primary hover:underline"
 						>
 							{t("settings:alphatabLinkGithub")}
-						</a>
+						</AppLink>
 						<span className="mx-2 text-muted-foreground">|</span>
-						<a
+						<AppLink
 							href="https://alphatab.net/"
-							target="_blank"
-							rel="noopener noreferrer"
 							className="text-xs text-primary hover:underline"
 						>
 							{t("settings:alphatabLinkWebsite")}
-						</a>
+						</AppLink>
 						<span className="mx-2 text-muted-foreground">|</span>
-						<a
+						<AppLink
 							href="https://alphatab.net/docs/alphatex/introduction"
-							target="_blank"
-							rel="noopener noreferrer"
 							className="text-xs text-primary hover:underline"
 						>
 							{t("settings:alphatabLinkAlphaTex")}
-						</a>
+						</AppLink>
 					</p>
 				</div>
 			</section>
@@ -132,7 +125,11 @@ export function AboutPage() {
 					</div>
 				)}
 				{!loading && !error && readmeContent && (
-					<TutorialRenderer content={readmeContent} allowHtml={true} />
+					<TutorialRenderer
+						content={readmeContent}
+						allowHtml={true}
+						sourcePath="README.md"
+					/>
 				)}
 			</section>
 		</div>

--- a/src/renderer/components/settings/RoadmapPage.tsx
+++ b/src/renderer/components/settings/RoadmapPage.tsx
@@ -45,7 +45,7 @@ export function RoadmapPage() {
 				</div>
 			)}
 			{!loading && !error && roadmapContent && (
-				<TutorialRenderer content={roadmapContent} />
+				<TutorialRenderer content={roadmapContent} sourcePath="ROADMAP.md" />
 			)}
 		</section>
 	);

--- a/src/renderer/components/settings/UpdatesPage.tsx
+++ b/src/renderer/components/settings/UpdatesPage.tsx
@@ -1,7 +1,8 @@
 import DOMPurify from "dompurify";
 import moment from "moment";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { AppLink } from "../ui/app-link";
 import { Button } from "../ui/button";
 
 interface ReleaseEntry {
@@ -19,6 +20,7 @@ export function UpdatesPage() {
 	const [releases, setReleases] = useState<ReleaseEntry[]>([]);
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
+	const releasesContainerRef = useRef<HTMLDivElement | null>(null);
 
 	const fetchReleases = useCallback(async () => {
 		setLoading(true);
@@ -130,6 +132,41 @@ export function UpdatesPage() {
 		}
 	};
 
+	useEffect(() => {
+		const container = releasesContainerRef.current;
+		if (!container) {
+			return;
+		}
+
+		const handleReleaseContentClick = (event: MouseEvent) => {
+			const target = event.target;
+			if (!(target instanceof HTMLElement)) {
+				return;
+			}
+
+			const anchor = target.closest("a");
+			if (!(anchor instanceof HTMLAnchorElement) || !anchor.href) {
+				return;
+			}
+
+			event.preventDefault();
+			void window.desktopAPI.openExternal(anchor.href).then((result) => {
+				if (!result?.success) {
+					console.error(
+						"[UpdatesPage] failed to open release link",
+						result?.error,
+						anchor.href,
+					);
+				}
+			});
+		};
+
+		container.addEventListener("click", handleReleaseContentClick);
+		return () => {
+			container.removeEventListener("click", handleReleaseContentClick);
+		};
+	});
+
 	return (
 		<div className="space-y-4">
 			<section className="bg-card border border-border rounded p-4">
@@ -174,7 +211,7 @@ export function UpdatesPage() {
 					</div>
 				)}
 
-				<div className="space-y-4">
+				<div className="space-y-4" ref={releasesContainerRef}>
 					{releases.map((release) => (
 						<div
 							key={release.id}
@@ -183,14 +220,12 @@ export function UpdatesPage() {
 							<div className="flex items-start justify-between gap-2">
 								<h4 className="text-sm font-medium flex-1">{release.title}</h4>
 								{release.link && (
-									<a
+									<AppLink
 										href={release.link}
-										target="_blank"
-										rel="noopener noreferrer"
 										className="text-xs text-primary hover:underline shrink-0"
 									>
 										{t("viewRelease")}
-									</a>
+									</AppLink>
 								)}
 							</div>
 							{release.updated && (

--- a/src/renderer/components/tutorial/MDXRenderer.tsx
+++ b/src/renderer/components/tutorial/MDXRenderer.tsx
@@ -1,9 +1,11 @@
 import { MDXProvider } from "@mdx-js/react";
 import type { MDXModule } from "mdx/types";
+import { AppLink } from "../ui/app-link";
 import { components as mdxComponents } from "./mdx-components";
 
 interface MDXRendererProps {
 	module: MDXModule;
+	sourcePath?: string;
 }
 
 // 合并自定义组件和 Markdown 元素样式
@@ -44,14 +46,12 @@ const allComponents = {
 		</blockquote>
 	),
 	a: ({ href, children }: { href?: string; children?: React.ReactNode }) => (
-		<a
+		<AppLink
 			href={href}
 			className="text-primary hover:underline break-words whitespace-normal"
-			target={href?.startsWith("http") ? "_blank" : undefined}
-			rel={href?.startsWith("http") ? "noopener noreferrer" : undefined}
 		>
 			{children}
-		</a>
+		</AppLink>
 	),
 	hr: () => <hr className="my-6 border-border" />,
 	strong: ({ children }: { children?: React.ReactNode }) => (
@@ -117,11 +117,23 @@ const allComponents = {
 	),
 };
 
-export function MDXRenderer({ module }: MDXRendererProps) {
+export function MDXRenderer({ module, sourcePath }: MDXRendererProps) {
 	const Content = module.default as React.ComponentType;
+	const componentsWithContext = {
+		...allComponents,
+		a: ({ href, children }: { href?: string; children?: React.ReactNode }) => (
+			<AppLink
+				href={href}
+				sourcePath={sourcePath}
+				className="text-primary hover:underline break-words whitespace-normal"
+			>
+				{children}
+			</AppLink>
+		),
+	};
 
 	return (
-		<MDXProvider components={allComponents}>
+		<MDXProvider components={componentsWithContext}>
 			<div className="prose prose-sm max-w-none dark:prose-invert">
 				<Content />
 			</div>

--- a/src/renderer/components/tutorial/TutorialRenderer.tsx
+++ b/src/renderer/components/tutorial/TutorialRenderer.tsx
@@ -3,17 +3,20 @@ import type { Components } from "react-markdown";
 import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
+import { AppLink } from "../ui/app-link";
 import { CodeBlock } from "./CodeBlock";
 import { TutorialImage } from "./TutorialImage";
 
 interface TutorialRendererProps {
 	content: string;
 	allowHtml?: boolean;
+	sourcePath?: string;
 }
 
 export function TutorialRenderer({
 	content,
 	allowHtml = true,
+	sourcePath,
 }: TutorialRendererProps) {
 	const components = {
 		pre: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
@@ -154,22 +157,13 @@ export function TutorialRenderer({
 		),
 
 		a: ({ href, children }: { href?: string; children?: React.ReactNode }) => (
-			<a
+			<AppLink
 				href={href}
+				sourcePath={sourcePath}
 				className="text-primary hover:underline break-words whitespace-normal"
-				target={
-					typeof href === "string" && href.startsWith("http")
-						? "_blank"
-						: undefined
-				}
-				rel={
-					typeof href === "string" && href.startsWith("http")
-						? "noopener noreferrer"
-						: undefined
-				}
 			>
 				{children}
-			</a>
+			</AppLink>
 		),
 
 		hr: () => <hr className="my-6 border-border" />,

--- a/src/renderer/components/ui/app-link.tsx
+++ b/src/renderer/components/ui/app-link.tsx
@@ -1,0 +1,81 @@
+import type { ComponentPropsWithoutRef, MouseEvent } from "react";
+import {
+	isExternalHref,
+	isHashHref,
+	normalizeExternalHref,
+	type RepoLinkContext,
+	resolveRepoRelativeHref,
+} from "../../lib/repo-links";
+
+type AnchorProps = Omit<ComponentPropsWithoutRef<"a">, "href">;
+
+export interface AppLinkProps extends AnchorProps, RepoLinkContext {
+	href?: string;
+}
+
+function isModifiedClick(event: MouseEvent<HTMLAnchorElement>): boolean {
+	return event.metaKey || event.ctrlKey || event.shiftKey || event.altKey;
+}
+
+export function AppLink({
+	href,
+	sourcePath,
+	repoUrl,
+	repoBranch,
+	onClick,
+	target,
+	rel,
+	...props
+}: AppLinkProps) {
+	const resolvedHref =
+		typeof href === "string"
+			? resolveRepoRelativeHref(href, {
+					sourcePath,
+					repoUrl,
+					repoBranch,
+				})
+			: href;
+	const normalizedHref =
+		typeof resolvedHref === "string"
+			? normalizeExternalHref(resolvedHref)
+			: resolvedHref;
+	const opensOutsideApp =
+		typeof normalizedHref === "string" &&
+		!isHashHref(normalizedHref) &&
+		isExternalHref(normalizedHref);
+	const resolvedTarget = target ?? (opensOutsideApp ? "_blank" : undefined);
+	const resolvedRel =
+		rel ?? (resolvedTarget === "_blank" ? "noopener noreferrer" : undefined);
+
+	const handleClick = async (event: MouseEvent<HTMLAnchorElement>) => {
+		onClick?.(event);
+		if (event.defaultPrevented || !normalizedHref || isModifiedClick(event)) {
+			return;
+		}
+		if (event.button !== 0 || !opensOutsideApp) {
+			return;
+		}
+
+		event.preventDefault();
+		const result = await window.desktopAPI?.openExternal?.(normalizedHref);
+		if (result?.success === false) {
+			console.error(
+				"[AppLink] failed to open external link",
+				result.error,
+				normalizedHref,
+			);
+		}
+	};
+
+	return (
+		<a
+			{...props}
+			href={normalizedHref}
+			target={resolvedTarget}
+			rel={resolvedRel}
+			onClick={(event) => {
+				void handleClick(event);
+			}}
+		/>
+	);
+}

--- a/src/renderer/lib/desktop-api.test.ts
+++ b/src/renderer/lib/desktop-api.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it } from "vitest";
-import { shouldUseTauriDesktopApi } from "./desktop-api";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createWebDesktopAPI, shouldUseTauriDesktopApi } from "./desktop-api";
+
+beforeEach(() => {
+	Object.defineProperty(globalThis, "window", {
+		value: {
+			open: vi.fn(),
+		},
+		configurable: true,
+	});
+});
 
 describe("tauri runtime detection", () => {
 	it("does not treat TAURI_ENV_PLATFORM alone as a runtime signal", () => {
@@ -52,5 +61,17 @@ describe("tauri runtime detection", () => {
 				userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X)",
 			}),
 		).toBe(false);
+	});
+
+	it("opens external links through the web runtime bridge", async () => {
+		const api = createWebDesktopAPI();
+		const result = await api.openExternal("https://example.com/docs");
+
+		expect(result).toEqual({ success: true });
+		expect(window.open).toHaveBeenCalledWith(
+			"https://example.com/docs",
+			"_blank",
+			"noopener,noreferrer",
+		);
 	});
 });

--- a/src/renderer/lib/desktop-api.ts
+++ b/src/renderer/lib/desktop-api.ts
@@ -329,6 +329,16 @@ export function createWebDesktopAPI(): DesktopAPI {
 			error: "Unsupported in web runtime",
 		}),
 
+		openExternal: async (target: string) => {
+			const opener = window.open;
+			if (typeof opener !== "function") {
+				return { success: false, error: "window-open-unavailable" };
+			}
+
+			opener(target, "_blank", "noopener,noreferrer");
+			return { success: true };
+		},
+
 		readAsset: async (relPath: string) => {
 			const normalized = relPath.replace(/^\/+/, "");
 			const candidatePaths = [normalized];

--- a/src/renderer/lib/repo-links.test.ts
+++ b/src/renderer/lib/repo-links.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+	isExternalHref,
+	isHashHref,
+	normalizeExternalHref,
+	resolveRepoRelativeHref,
+} from "./repo-links";
+
+describe("repo link resolution", () => {
+	it("keeps external URLs unchanged", () => {
+		expect(resolveRepoRelativeHref("https://example.com/docs")).toBe(
+			"https://example.com/docs",
+		);
+		expect(isExternalHref("mailto:hello@example.com")).toBe(true);
+		expect(normalizeExternalHref("//example.com/docs")).toBe(
+			"https://example.com/docs",
+		);
+	});
+
+	it("keeps hash links unchanged", () => {
+		expect(resolveRepoRelativeHref("#features")).toBe("#features");
+		expect(isHashHref("#features")).toBe(true);
+	});
+
+	it("keeps relative links unchanged without explicit repo context", () => {
+		expect(resolveRepoRelativeHref("./getting-started.md")).toBe(
+			"./getting-started.md",
+		);
+	});
+
+	it("rewrites README relative links to GitHub blob URLs", () => {
+		expect(
+			resolveRepoRelativeHref("./README.zh.md", {
+				sourcePath: "README.md",
+			}),
+		).toBe("https://github.com/LIUBINfighter/Tabst.app/blob/dev/README.zh.md");
+	});
+
+	it("rewrites nested repo links relative to the source path", () => {
+		expect(
+			resolveRepoRelativeHref("../README.md", {
+				sourcePath: "docs/ROADMAP.md",
+			}),
+		).toBe("https://github.com/LIUBINfighter/Tabst.app/blob/dev/README.md");
+	});
+
+	it("preserves query and hash suffixes on rewritten links", () => {
+		expect(
+			resolveRepoRelativeHref(
+				"./docs/dev/TAURI_MIGRATION_STATUS.md?plain=1#next",
+				{
+					sourcePath: "README.md",
+				},
+			),
+		).toBe(
+			"https://github.com/LIUBINfighter/Tabst.app/blob/dev/docs/dev/TAURI_MIGRATION_STATUS.md?plain=1#next",
+		);
+	});
+
+	it("preserves slash-separated branch names in GitHub blob URLs", () => {
+		expect(
+			resolveRepoRelativeHref("./README.zh.md", {
+				sourcePath: "README.md",
+				repoBranch: "feature/link-handling",
+			}),
+		).toBe(
+			"https://github.com/LIUBINfighter/Tabst.app/blob/feature/link-handling/README.zh.md",
+		);
+	});
+});

--- a/src/renderer/lib/repo-links.ts
+++ b/src/renderer/lib/repo-links.ts
@@ -1,0 +1,112 @@
+export const TABST_GITHUB_REPO_URL =
+	"https://github.com/LIUBINfighter/Tabst.app";
+export const TABST_GITHUB_DEFAULT_BRANCH = "dev";
+
+export interface RepoLinkContext {
+	sourcePath?: string;
+	repoUrl?: string;
+	repoBranch?: string;
+}
+
+const EXTERNAL_PROTOCOL_RE = /^[a-zA-Z][a-zA-Z\d+.-]*:/;
+
+interface HrefParts {
+	path: string;
+	query: string;
+	hash: string;
+}
+
+function splitHrefParts(href: string): HrefParts {
+	const hashIndex = href.indexOf("#");
+	const queryIndex = href.indexOf("?");
+	const firstSuffixIndex = [hashIndex, queryIndex]
+		.filter((value) => value >= 0)
+		.sort((left, right) => left - right)[0];
+	const path =
+		firstSuffixIndex === undefined ? href : href.slice(0, firstSuffixIndex);
+	const query =
+		queryIndex >= 0
+			? href.slice(
+					queryIndex,
+					hashIndex >= 0 && hashIndex > queryIndex ? hashIndex : undefined,
+				)
+			: "";
+	const hash = hashIndex >= 0 ? href.slice(hashIndex) : "";
+	return { path, query, hash };
+}
+
+function normalizePath(path: string): string {
+	const segments = path.split("/");
+	const normalized: string[] = [];
+
+	for (const segment of segments) {
+		if (!segment || segment === ".") {
+			continue;
+		}
+		if (segment === "..") {
+			normalized.pop();
+			continue;
+		}
+		normalized.push(segment);
+	}
+
+	return normalized.join("/");
+}
+
+function encodePathSegments(path: string): string {
+	return path
+		.split("/")
+		.filter(Boolean)
+		.map((segment) => encodeURIComponent(segment))
+		.join("/");
+}
+
+function encodeBranchSegments(branch: string): string {
+	return branch
+		.split("/")
+		.filter(Boolean)
+		.map((segment) => encodeURIComponent(segment))
+		.join("/");
+}
+
+export function isHashHref(href: string): boolean {
+	return href.startsWith("#");
+}
+
+export function isExternalHref(href: string): boolean {
+	return EXTERNAL_PROTOCOL_RE.test(href) || href.startsWith("//");
+}
+
+export function normalizeExternalHref(href: string): string {
+	return href.startsWith("//") ? `https:${href}` : href;
+}
+
+export function resolveRepoRelativeHref(
+	href: string,
+	context: RepoLinkContext = {},
+): string {
+	if (!href || isHashHref(href) || isExternalHref(href)) {
+		return href;
+	}
+	if (!context.sourcePath && !context.repoUrl && !context.repoBranch) {
+		return href;
+	}
+
+	const { path, query, hash } = splitHrefParts(href);
+	const repoUrl = context.repoUrl ?? TABST_GITHUB_REPO_URL;
+	const repoBranch = context.repoBranch ?? TABST_GITHUB_DEFAULT_BRANCH;
+	const sourcePath = context.sourcePath?.trim();
+	const sourceSegments = sourcePath
+		? sourcePath.split("/").filter(Boolean).slice(0, -1)
+		: [];
+	const targetSegments = path.split("/").filter(Boolean);
+	const normalizedPath = path.startsWith("/")
+		? normalizePath(targetSegments.join("/"))
+		: normalizePath([...sourceSegments, ...targetSegments].join("/"));
+
+	if (!normalizedPath) {
+		return href;
+	}
+
+	return `${repoUrl.replace(/\/+$/, "")}/blob/${encodeBranchSegments(repoBranch)}/${encodePathSegments(normalizedPath)}${query}${hash}`;
+}

--- a/src/renderer/lib/tauri-desktop-api.ts
+++ b/src/renderer/lib/tauri-desktop-api.ts
@@ -189,6 +189,17 @@ export function createTauriDesktopAPI(): DesktopAPI {
 			}
 		},
 
+		openExternal: async (target: string) => {
+			try {
+				return await invokeCommand<{ success: boolean; error?: string } | null>(
+					"open_external",
+					{ target },
+				);
+			} catch (error) {
+				return { success: false, error: toErrorMessage(error) };
+			}
+		},
+
 		readAsset: async (relPath: string): Promise<Uint8Array> => {
 			const data = await invokeCommand<number[] | Uint8Array>("read_asset", {
 				rel_path: relPath,

--- a/src/renderer/types/desktop.d.ts
+++ b/src/renderer/types/desktop.d.ts
@@ -67,6 +67,9 @@ export interface DesktopAPI {
 	revealInFolder: (
 		filePath: string,
 	) => Promise<{ success: boolean; error?: string } | null>;
+	openExternal: (
+		target: string,
+	) => Promise<{ success: boolean; error?: string } | null>;
 	readAsset: (relPath: string) => Promise<Uint8Array>;
 	selectFolder: () => Promise<string | null>;
 	readFile: (filePath: string) => Promise<{ content: string; error?: string }>;


### PR DESCRIPTION
## Issues
<!-- Strongly recommended: link a related issue here when available -->
Fixes #117

## Proposed changes
<!-- Describe the proposed changes -->

- route desktop external links through a unified `openExternal` bridge instead of relying on raw anchors inside the webview
- resolve repo-relative markdown links (for example `./README.zh.md`) to GitHub blob URLs so README / roadmap content can open correctly
- apply the shared link flow across tutorial/settings/update surfaces for consistent behavior in both Tauri and web runtimes
- includes a Tauri-side allowlist for external schemes: `http`, `https`, `mailto`, `tel`
- normalizes protocol-relative links and preserves slash-separated branch names in generated GitHub blob URLs

## Checklist
- [x] I consent that this change becomes part of Tabst under its current or any future open source license
- [x] Changes are implemented
- [ ] New tests were added <!-- Strongly recommended. If no tests were added, explain why. -->

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
