### PR TITLE
Fix/issue 108 light theme

### DIFF
--- a/src/renderer/components/settings/EditorPreview.tsx
+++ b/src/renderer/components/settings/EditorPreview.tsx
@@ -2,6 +2,7 @@ import { EditorState } from "@codemirror/state";
 import { EditorView, keymap, lineNumbers } from "@codemirror/view";
 import { useEffect, useRef } from "react";
 import { createAlphaTexHighlightForTheme } from "../../lib/alphatex-highlight";
+import { createCMThemeFromEditorTheme } from "../../lib/codemirror-themes/create-cm-theme";
 import { useTheme } from "../../lib/theme-system/use-theme";
 
 const SAMPLE_ALPHATEX_CODE = `// Welcome to Tabst - Guitar Tab Editor
@@ -31,7 +32,7 @@ const SAMPLE_ALPHATEX_CODE = `// Welcome to Tabst - Guitar Tab Editor
 `;
 
 export function EditorPreview() {
-	const { editorTheme } = useTheme();
+	const { editorTheme, isDark } = useTheme();
 	const editorRef = useRef<HTMLDivElement>(null);
 	const viewRef = useRef<EditorView | null>(null);
 
@@ -44,53 +45,13 @@ export function EditorPreview() {
 		}
 
 		const alphaTexHighlight = createAlphaTexHighlightForTheme(editorTheme);
-
-		const baseTheme = EditorView.theme({
-			"&": {
-				backgroundColor: "hsl(var(--card))",
-				color: "hsl(var(--foreground))",
-				fontSize: "14px",
-				fontFamily:
-					'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
-				borderRadius: "6px",
-				height: "100%",
-				display: "flex",
-				flexDirection: "column",
-			},
-			".cm-scroller": {
-				overflowX: "hidden",
-				overflowY: "auto",
-				height: "100%",
-				minHeight: "0",
-				fontFamily:
-					'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
-				scrollbarWidth: "thin",
-			},
+		const baseTheme = createCMThemeFromEditorTheme(editorTheme, isDark);
+		const previewSpacingTheme = EditorView.theme({
 			".cm-content": {
 				padding: "8px 0",
 			},
 			".cm-line": {
 				padding: "0 8px",
-			},
-			".cm-gutters": {
-				backgroundColor: "hsl(var(--card))",
-				border: "none",
-				color: "hsl(var(--muted-foreground))",
-			},
-			".cm-activeLineGutter": {
-				backgroundColor: "transparent",
-			},
-			".cm-activeLine": {
-				backgroundColor: "hsl(var(--muted) / 0.06)",
-			},
-			".cm-cursor": {
-				borderLeftColor: "hsl(var(--primary))",
-			},
-			".cm-selectionBackground": {
-				backgroundColor: "var(--selection-overlay)",
-				color: "inherit",
-				opacity: "1",
-				mixBlendMode: "normal",
 			},
 		});
 
@@ -99,7 +60,8 @@ export function EditorPreview() {
 		const state = EditorState.create({
 			doc: SAMPLE_ALPHATEX_CODE,
 			extensions: [
-				baseTheme,
+				...baseTheme,
+				previewSpacingTheme,
 				...alphaTexHighlight,
 				lineNumbers(),
 				readOnlyExtension,
@@ -119,7 +81,7 @@ export function EditorPreview() {
 				viewRef.current = null;
 			}
 		};
-	}, [editorTheme]);
+	}, [editorTheme, isDark]);
 
 	return (
 		<div className="mt-4">

--- a/src/renderer/lib/codemirror-themes/create-cm-theme.ts
+++ b/src/renderer/lib/codemirror-themes/create-cm-theme.ts
@@ -2,32 +2,16 @@ import { HighlightStyle, syntaxHighlighting } from "@codemirror/language";
 import type { Extension } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { tags } from "@lezer/highlight";
+import { getEditorThemeForUi } from "../theme-system/editor-theme-adapter";
 import type { EditorTheme } from "../theme-system/types";
 
 export function createCMThemeFromEditorTheme(
 	editorTheme: EditorTheme,
 	isDarkUI: boolean,
 ): Extension[] {
-	const useLightSafeDracula = editorTheme.id === "dracula" && !isDarkUI;
-	const colors = useLightSafeDracula
-		? {
-				...editorTheme.colors,
-				keyword: "#c2185b",
-				operator: "#c2185b",
-				string: "#8b5e00",
-				number: "#7e57c2",
-				atom: "#b45309",
-				function: "#0f766e",
-				tag: "#c2185b",
-				attribute: "#0f766e",
-				variable: "hsl(var(--foreground))",
-				bracket: "hsl(var(--foreground))",
-				atomBackground: "hsl(var(--primary) / 0.16)",
-				matchBackground: "hsl(var(--muted) / 0.24)",
-				selectionMatch: "hsl(var(--primary) / 0.28)",
-			}
-		: editorTheme.colors;
-	const cm = editorTheme.cmConfig;
+	const effectiveTheme = getEditorThemeForUi(editorTheme, isDarkUI);
+	const colors = effectiveTheme.colors;
+	const cm = effectiveTheme.cmConfig;
 
 	const highlightStyle = HighlightStyle.define([
 		{ tag: tags.comment, color: colors.comment },
@@ -104,27 +88,19 @@ export function createCMThemeFromEditorTheme(
 
 	if (cm) {
 		themeStyles["&"].backgroundColor = cm.background;
-		themeStyles["&"].color = useLightSafeDracula
-			? "hsl(var(--foreground))"
-			: cm.foreground;
-		themeStyles[".cm-gutters"].color = useLightSafeDracula
-			? "hsl(var(--muted-foreground))"
-			: cm.gutterForeground;
+		themeStyles["&"].color = cm.foreground;
+		themeStyles[".cm-gutters"].color = cm.gutterForeground;
 		themeStyles[".cm-selectionBackground, .cm-selection"] = {
-			backgroundColor: useLightSafeDracula
-				? "hsl(var(--primary) / 0.18)"
-				: cm.selection,
+			backgroundColor: cm.selection,
 			color: "inherit",
 			opacity: "1",
 			mixBlendMode: "normal",
 		};
 		themeStyles[".cm-activeLine"] = {
-			backgroundColor: useLightSafeDracula
-				? "hsl(var(--muted) / 0.14)"
-				: cm.lineHighlight,
+			backgroundColor: cm.lineHighlight,
 		};
 		themeStyles[".cm-cursor"] = {
-			borderLeftColor: useLightSafeDracula ? "hsl(var(--primary))" : cm.cursor,
+			borderLeftColor: cm.cursor,
 		};
 	} else {
 		themeStyles["&"].backgroundColor = "hsl(var(--card))";
@@ -137,8 +113,8 @@ export function createCMThemeFromEditorTheme(
 	}
 
 	const isDark =
-		editorTheme.variant === "dark" ||
-		(editorTheme.variant === "universal" && isDarkUI);
+		effectiveTheme.variant === "dark" ||
+		(effectiveTheme.variant === "universal" && isDarkUI);
 	const baseTheme = EditorView.theme(themeStyles, { dark: isDark });
 
 	return [baseTheme, syntaxHighlighting(highlightStyle)];

--- a/src/renderer/lib/theme-system/editor-theme-adapter.test.ts
+++ b/src/renderer/lib/theme-system/editor-theme-adapter.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { getEditorThemeForUi } from "./editor-theme-adapter";
+import { getEditorTheme } from "./theme-registry";
+
+describe("editor theme adapter", () => {
+	it("keeps universal themes unchanged in light UI", () => {
+		const theme = getEditorTheme("github");
+		expect(theme).toBeDefined();
+		if (!theme) {
+			throw new Error("missing github editor theme");
+		}
+
+		expect(getEditorThemeForUi(theme, false)).toBe(theme);
+	});
+
+	it("keeps dark themes unchanged in dark UI", () => {
+		const theme = getEditorTheme("nord");
+		expect(theme).toBeDefined();
+		if (!theme) {
+			throw new Error("missing nord editor theme");
+		}
+
+		expect(getEditorThemeForUi(theme, true)).toBe(theme);
+	});
+
+	it("adapts dark-only themes for light UI readability", () => {
+		const theme = getEditorTheme("nord");
+		expect(theme).toBeDefined();
+		if (!theme) {
+			throw new Error("missing nord editor theme");
+		}
+
+		const adapted = getEditorThemeForUi(theme, false);
+
+		expect(adapted).not.toBe(theme);
+		expect(adapted.variant).toBe("universal");
+		expect(adapted.colors.variable).toBe("hsl(var(--foreground))");
+		expect(adapted.colors.bracket).toBe("hsl(var(--foreground))");
+		expect(adapted.cmConfig?.foreground).toBe("hsl(var(--foreground))");
+		expect(adapted.cmConfig?.selection).toBe("hsl(var(--primary) / 0.16)");
+	});
+});

--- a/src/renderer/lib/theme-system/editor-theme-adapter.test.ts
+++ b/src/renderer/lib/theme-system/editor-theme-adapter.test.ts
@@ -38,5 +38,21 @@ describe("editor theme adapter", () => {
 		expect(adapted.colors.bracket).toBe("hsl(var(--foreground))");
 		expect(adapted.cmConfig?.foreground).toBe("hsl(var(--foreground))");
 		expect(adapted.cmConfig?.selection).toBe("hsl(var(--primary) / 0.16)");
+		expect(adapted.colors.selectionMatch).toBe(theme.colors.selectionMatch);
+	});
+
+	it("softens dracula tokens when used in light UI", () => {
+		const theme = getEditorTheme("dracula");
+		expect(theme).toBeDefined();
+		if (!theme) {
+			throw new Error("missing dracula editor theme");
+		}
+
+		const adapted = getEditorThemeForUi(theme, false);
+
+		expect(adapted.colors.keyword).toBe("#c2185b");
+		expect(adapted.colors.string).toBe("#8b5e00");
+		expect(adapted.colors.function).toBe("#0f766e");
+		expect(adapted.colors.comment).toBe("#6b7280");
 	});
 });

--- a/src/renderer/lib/theme-system/editor-theme-adapter.ts
+++ b/src/renderer/lib/theme-system/editor-theme-adapter.ts
@@ -1,18 +1,42 @@
 import type { EditorTheme } from "./types";
 
+function getLightModeTokenOverrides(
+	editorTheme: EditorTheme,
+): Partial<EditorTheme["colors"]> {
+	if (editorTheme.id === "dracula") {
+		return {
+			comment: "#6b7280",
+			keyword: "#c2185b",
+			operator: "#c2185b",
+			string: "#8b5e00",
+			number: "#7e57c2",
+			atom: "#b45309",
+			function: "#0f766e",
+			tag: "#c2185b",
+			attribute: "#0f766e",
+		};
+	}
+
+	return {};
+}
+
 function adaptDarkEditorThemeForLightUi(editorTheme: EditorTheme): EditorTheme {
+	const lightModeTokenOverrides = getLightModeTokenOverrides(editorTheme);
+
 	return {
 		...editorTheme,
 		variant: "universal",
 		colors: {
 			...editorTheme.colors,
+			...lightModeTokenOverrides,
 			variable: "hsl(var(--foreground))",
 			bracket: "hsl(var(--foreground))",
 			atomBackground:
 				editorTheme.colors.atomBackground ?? "hsl(var(--primary) / 0.14)",
 			matchBackground:
 				editorTheme.colors.matchBackground ?? "hsl(var(--muted) / 0.18)",
-			selectionMatch: "hsl(var(--primary) / 0.22)",
+			selectionMatch:
+				editorTheme.colors.selectionMatch ?? "hsl(var(--primary) / 0.22)",
 		},
 		cmConfig: {
 			background: "hsl(var(--card))",

--- a/src/renderer/lib/theme-system/editor-theme-adapter.ts
+++ b/src/renderer/lib/theme-system/editor-theme-adapter.ts
@@ -1,0 +1,38 @@
+import type { EditorTheme } from "./types";
+
+function adaptDarkEditorThemeForLightUi(editorTheme: EditorTheme): EditorTheme {
+	return {
+		...editorTheme,
+		variant: "universal",
+		colors: {
+			...editorTheme.colors,
+			variable: "hsl(var(--foreground))",
+			bracket: "hsl(var(--foreground))",
+			atomBackground:
+				editorTheme.colors.atomBackground ?? "hsl(var(--primary) / 0.14)",
+			matchBackground:
+				editorTheme.colors.matchBackground ?? "hsl(var(--muted) / 0.18)",
+			selectionMatch: "hsl(var(--primary) / 0.22)",
+		},
+		cmConfig: {
+			background: "hsl(var(--card))",
+			foreground: "hsl(var(--foreground))",
+			gutterBackground: "transparent",
+			gutterForeground: "hsl(var(--muted-foreground))",
+			lineHighlight: "hsl(var(--muted) / 0.14)",
+			selection: "hsl(var(--primary) / 0.16)",
+			cursor: "hsl(var(--primary))",
+		},
+	};
+}
+
+export function getEditorThemeForUi(
+	editorTheme: EditorTheme,
+	isDarkUI: boolean,
+): EditorTheme {
+	if (isDarkUI || editorTheme.variant !== "dark") {
+		return editorTheme;
+	}
+
+	return adaptDarkEditorThemeForLightUi(editorTheme);
+}

--- a/src/renderer/lib/theme-system/theme-registry.ts
+++ b/src/renderer/lib/theme-system/theme-registry.ts
@@ -288,12 +288,12 @@ const obsidian: UITheme = {
 			foreground: "rgb(167, 139, 250)",
 		},
 		score: {
-			mainGlyph: "#f0ebff",
-			secondaryGlyph: "rgba(240, 235, 255, 0.6)",
+			mainGlyph: "#d8cfee",
+			secondaryGlyph: "rgba(216, 207, 238, 0.58)",
 			staffLine: "#4a4458",
 			barSeparator: "#4a4458",
 			barNumber: "#9ca3af",
-			scoreInfo: "#d1d5db",
+			scoreInfo: "#b8add4",
 		},
 		playerCursor: {
 			background: "rgba(167, 139, 250, 0.4)",

--- a/src/renderer/lib/theme-system/theme-registry.ts
+++ b/src/renderer/lib/theme-system/theme-registry.ts
@@ -893,7 +893,7 @@ const vscodeEditorTheme: EditorTheme = {
 		keyword: "#569cd6",
 		operator: "#d4d4d4",
 		string: "#ce9178",
-		number: "#b5cea8",
+		number: "#7fa06a",
 		atom: "#dcdcaa",
 		function: "#dcdcaa",
 		tag: "#569cd6",

--- a/src/renderer/lib/theme-system/use-theme.ts
+++ b/src/renderer/lib/theme-system/use-theme.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo } from "react";
 import { useAppStore } from "../../store/appStore";
 import { useThemeStore } from "../../store/themeStore";
+import { getEditorThemeForUi } from "./editor-theme-adapter";
 import { getEditorTheme, getUITheme } from "./theme-registry";
 import type { EditorTheme, ThemeMode, UITheme, UIThemeColors } from "./types";
 
@@ -47,8 +48,8 @@ export function useTheme(): UseThemeReturn {
 				`Editor theme "${currentEditorTheme}" not found and fallback "github" also not found`,
 			);
 		}
-		return theme;
-	}, [currentEditorTheme]);
+		return getEditorThemeForUi(theme, isDark);
+	}, [currentEditorTheme, isDark]);
 
 	const effectiveColors = useMemo(() => {
 		return uiTheme[effectiveVariant];


### PR DESCRIPTION
## Issues
<!-- Strongly recommended: link a related issue here when available -->
Fixes #108 

## Proposed changes
<!-- Describe the proposed changes -->

This PR fixes issue #108 around themes that do not render well in light mode, and follows up on remaining readability hotspots in the Obsidian and VS Code styles.
这个 PR 主要修复了 issue #108 中“部分主题在亮色模式下显示效果不佳”的问题，并继续收敛了 Obsidian / VS Code 风格下仍然偏亮的文本颜色。

### What changed
- added a shared light-safe adaptation path for dark-only editor themes
  - prevents dark-oriented editor palettes from keeping overly bright foreground behavior on light UI surfaces
- aligned the settings editor preview with the real CodeMirror theme pipeline
  - avoids preview/editor mismatches
- toned down Obsidian readability hotspots
  - softened some Dracula-derived token colors when used with Obsidian in light UI
  - reduced the brightness of Obsidian dark score preview glyph and info colors
- softened the VS Code number token color
  - replaced the overly bright green with a more restrained value for better readability

### Scope
- CodeMirror editor syntax highlighting
- AlphaTex highlighting
- settings editor preview
- Obsidian score preview colors

### 本次修改包含
- 为 dark-only editor themes 增加统一的 light-safe 适配层
  - 避免在 light UI 下继续直接使用深色主题原本偏亮的前景色
- 让设置页中的编辑器预览复用真实编辑器的 CodeMirror 主题路径
  - 避免预览与实际编辑器效果不一致
- 调整 Obsidian 风格的可读性热点
  - 降低 light UI 下 Obsidian 默认搭配 Dracula 时部分 token 的亮度
  - 降低 Obsidian dark 模式下曲谱预览主字形和说明文字的亮度
- 调整 VS Code 风格中 number token 的颜色
  - 将数字高亮从过亮的绿色调低为更柔和的绿色，减少刺眼感

### 影响范围
- 编辑器语法高亮（CodeMirror）
- AlphaTex 高亮
- 设置页编辑器预览
- Obsidian 主题下的曲谱预览颜色

## Checklist
- [x] I consent that this change becomes part of Tabst under its current or any future open source license
- [x] Changes are implemented
- [ ] New tests were added <!-- Strongly recommended. If no tests were added, explain why. -->

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
