### PR TITLE
fix: recover alphaTab audio output after long idle playback

### DIFF
--- a/src/renderer/components/Preview.tsx
+++ b/src/renderer/components/Preview.tsx
@@ -52,6 +52,7 @@ import {
 	createPlaybackFrameGate,
 	type PlaybackFrameGate,
 } from "../lib/playback-frame-gate";
+import { prepareAlphaTabAudioForPlayback } from "../lib/player-audio-recovery";
 import {
 	PREVIEW_COMMAND_EVENT,
 	type PreviewCommandId,
@@ -424,6 +425,39 @@ export default function Preview({
 	useEffect(() => {
 		editorHasFocusRef.current = editorHasFocus;
 	}, [editorHasFocus]);
+
+	const recoverPlaybackAudio = useCallback(async () => {
+		const api = apiRef.current;
+		if (!api) {
+			return;
+		}
+
+		const recovery = await prepareAlphaTabAudioForPlayback(api);
+		if (recovery.didAttemptActivation) {
+			console.info(
+				`[Preview] playback audio recovery ${JSON.stringify(recovery)}`,
+			);
+		}
+	}, []);
+
+	useEffect(() => {
+		const handleWindowFocus = () => {
+			void recoverPlaybackAudio();
+		};
+		const handleVisibilityChange = () => {
+			if (!document.hidden) {
+				void recoverPlaybackAudio();
+			}
+		};
+
+		window.addEventListener("focus", handleWindowFocus);
+		document.addEventListener("visibilitychange", handleVisibilityChange);
+
+		return () => {
+			window.removeEventListener("focus", handleWindowFocus);
+			document.removeEventListener("visibilitychange", handleVisibilityChange);
+		};
+	}, [recoverPlaybackAudio]);
 
 	useEffect(() => {
 		latestContentRef.current = content ?? "";
@@ -1148,6 +1182,7 @@ export default function Preview({
 							};
 
 							const playNow = async (delayMs = 0) => {
+								await recoverPlaybackAudio();
 								const ready = await ensurePlaybackReady();
 								if (!ready) {
 									console.error(
@@ -1164,7 +1199,15 @@ export default function Preview({
 										window.setTimeout(resolve, delayMs),
 									);
 								}
-								const didPlay = api.play?.();
+								let didPlay = api.play?.();
+								if (!didPlay && currentSoundFontUrlRef.current) {
+									await loadSoundFontFromUrl(
+										api,
+										currentSoundFontUrlRef.current,
+									);
+									await recoverPlaybackAudio();
+									didPlay = api.play?.();
+								}
 								console.info(
 									`[Preview] api.play() invoked ${JSON.stringify({ didPlay, isReadyForPlayback: api.isReadyForPlayback, tickPosition: api.tickPosition })}`,
 								);
@@ -1862,6 +1905,7 @@ export default function Preview({
 		setPlaybackProgressIfChanged,
 		setPlayerCursorIfChanged,
 		setPlayerIsPlayingIfChanged,
+		recoverPlaybackAudio,
 	]);
 
 	// 内容更新：仅调用 tex，不销毁 API，避免闪烁

--- a/src/renderer/lib/player-audio-recovery.test.ts
+++ b/src/renderer/lib/player-audio-recovery.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import { prepareAlphaTabAudioForPlayback } from "./player-audio-recovery";
+
+describe("prepareAlphaTabAudioForPlayback", () => {
+	it("resumes suspended audio output before playback", async () => {
+		const activate = vi.fn((resumedCallback?: () => void) => {
+			output.context.state = "running";
+			resumedCallback?.();
+		});
+		const output = {
+			context: {
+				state: "suspended",
+				resume: vi.fn(async () => {
+					output.context.state = "running";
+				}),
+			},
+			activate,
+		};
+
+		const result = await prepareAlphaTabAudioForPlayback({
+			player: { output },
+		});
+
+		expect(activate).toHaveBeenCalledTimes(1);
+		expect(result.didAttemptActivation).toBe(true);
+		expect(result.finalState).toBe("running");
+	});
+
+	it("still activates running audio output to refresh playback path", async () => {
+		const activate = vi.fn();
+		const result = await prepareAlphaTabAudioForPlayback({
+			player: {
+				output: {
+					context: {
+						state: "running",
+					},
+					activate,
+				},
+			},
+		});
+
+		expect(activate).toHaveBeenCalledTimes(1);
+		expect(result.finalState).toBe("running");
+	});
+
+	it("safely no-ops when no player output is available", async () => {
+		const result = await prepareAlphaTabAudioForPlayback({});
+
+		expect(result.didAttemptActivation).toBe(false);
+		expect(result.finalState).toBeNull();
+	});
+});

--- a/src/renderer/lib/player-audio-recovery.ts
+++ b/src/renderer/lib/player-audio-recovery.ts
@@ -1,0 +1,83 @@
+interface RecoverableAudioContextLike {
+	state?: string;
+	resume?: () => Promise<void>;
+}
+
+interface RecoverableAudioOutputLike {
+	context?: RecoverableAudioContextLike | null;
+	activate?: (resumedCallback?: () => void) => void;
+}
+
+interface RecoverableAlphaTabPlayerLike {
+	output?: RecoverableAudioOutputLike | null;
+}
+
+export interface RecoverableAlphaTabApiLike {
+	player?: RecoverableAlphaTabPlayerLike | null;
+}
+
+export interface AudioRecoveryResult {
+	didAttemptActivation: boolean;
+	initialState: string | null;
+	finalState: string | null;
+}
+
+function isRecoverableAudioState(state: string | undefined): boolean {
+	return state === "suspended" || state === "interrupted";
+}
+
+export async function prepareAlphaTabAudioForPlayback(
+	api: RecoverableAlphaTabApiLike,
+): Promise<AudioRecoveryResult> {
+	const output = api.player?.output;
+	if (!output?.activate) {
+		return {
+			didAttemptActivation: false,
+			initialState: output?.context?.state ?? null,
+			finalState: output?.context?.state ?? null,
+		};
+	}
+
+	const initialState = output.context?.state ?? null;
+
+	if (isRecoverableAudioState(output.context?.state)) {
+		await new Promise<void>((resolve) => {
+			let settled = false;
+			const finish = () => {
+				if (settled) {
+					return;
+				}
+				settled = true;
+				resolve();
+			};
+
+			try {
+				output.activate?.(finish);
+			} catch {
+				finish();
+				return;
+			}
+
+			window.setTimeout(finish, 150);
+		});
+
+		if (
+			isRecoverableAudioState(output.context?.state) &&
+			output.context?.resume
+		) {
+			try {
+				await output.context.resume();
+			} catch {}
+		}
+	} else {
+		try {
+			output.activate();
+		} catch {}
+	}
+
+	return {
+		didAttemptActivation: true,
+		initialState,
+		finalState: output.context?.state ?? null,
+	};
+}


### PR DESCRIPTION
## Issues
<!-- Strongly recommended: link a related issue here when available -->
Fixes #115 

## Proposed changes
- add a playback audio recovery helper for alphaTab WebAudio output
- attempt audio recovery before starting playback so long-lived sessions do not stay silently stuck
- retry playback after reloading the soundfont when the first play attempt does not recover audio
- trigger the same recovery flow when the app regains focus or becomes visible again
- add regression tests covering suspended/running/missing player-output recovery paths

## Checklist
- [x] I consent that this change becomes part of Tabst under its current or any future open source license
- [x] Changes are implemented
- [x] New tests were added <!-- Strongly recommended. If no tests were added, explain why. -->

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
