### PR TITLE
fix: harden tauri path scoping and restore persistence flows

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,6 +21,9 @@ tauri-plugin-updater = "2.9"
 trash = "5.2"
 walkdir = "2.5"
 
+[dev-dependencies]
+tauri = { version = "2.0", features = ["test", "webview-data-url"] }
+
 [features]
 default = ["custom-protocol"]
 custom-protocol = ["tauri/custom-protocol"]

--- a/src-tauri/src/fs_commands.rs
+++ b/src-tauri/src/fs_commands.rs
@@ -235,9 +235,15 @@ pub(crate) fn save_file(file_path: String, content: String) -> SaveResult {
 
 #[tauri::command]
 pub(crate) fn load_app_state(app: tauri::AppHandle) -> AppStateWithContent {
+    load_app_state_with_handle(&app)
+}
+
+pub(crate) fn load_app_state_with_handle<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+) -> AppStateWithContent {
     register_persisted_repos(&crate::repo_commands::load_repos());
 
-    let state_file = match app_state_path(&app) {
+    let state_file = match app_state_path(app) {
         Ok(path) => path,
         Err(_) => {
             return AppStateWithContent {
@@ -260,6 +266,7 @@ pub(crate) fn load_app_state(app: tauri::AppHandle) -> AppStateWithContent {
     let mut files: Vec<AppStateWithContentFile> = Vec::new();
     for file in state.files {
         let path = PathBuf::from(&file.path);
+        let _ = register_allowed_file(&path);
         let (authorized_path, _) = match authorize_existing_workspace_path(&path) {
             Ok(value) => value,
             Err(_) => continue,

--- a/src-tauri/src/fs_commands.rs
+++ b/src-tauri/src/fs_commands.rs
@@ -6,8 +6,11 @@ use rfd::FileDialog;
 use tauri::Manager;
 
 use crate::{
-    app_state_path, asset_virtual_path_candidates, default_save_dir, normalize_non_empty_path,
-    now_ms, rename_path, sanitize_name, to_error, AppState, AppStateWithContent,
+    app_state_path, asset_virtual_path_candidates, authorize_existing_path_in_scope,
+    authorize_existing_workspace_path, authorize_target_path_in_scope, canonicalize_existing_path,
+    default_save_dir, normalize_non_empty_path, now_ms, register_allowed_file,
+    register_allowed_root, register_persisted_repos, rename_path, replace_registered_exact_file,
+    sanitize_name, to_error, validate_child_name, AppState, AppStateWithContent,
     AppStateWithContentFile, BasicResult, FileResult, FolderResult, OperationResult,
     ReadFileBytesResponse, ReadFileResponse, SaveResult,
 };
@@ -42,8 +45,10 @@ pub(crate) fn open_file(extensions: Vec<String>) -> Option<FileResult> {
     let content = fs::read_to_string(&selected).ok()?;
     let name = selected.file_name()?.to_string_lossy().to_string();
 
+    let registered_path = register_allowed_file(&selected).ok()?;
+
     Some(FileResult {
-        path: selected.to_string_lossy().to_string(),
+        path: registered_path.to_string_lossy().to_string(),
         name,
         content,
     })
@@ -53,6 +58,7 @@ pub(crate) fn open_file(extensions: Vec<String>) -> Option<FileResult> {
 pub(crate) fn select_folder() -> Option<String> {
     FileDialog::new()
         .pick_folder()
+        .and_then(|path| register_allowed_root(&path).ok())
         .map(|path| path.to_string_lossy().to_string())
 }
 
@@ -62,10 +68,20 @@ pub(crate) fn create_file(
     preferred_dir: Option<String>,
 ) -> Option<FileResult> {
     let save_dir = preferred_dir
-        .and_then(|value| normalize_non_empty_path(&value))
+        .and_then(|value| {
+            normalize_non_empty_path(&value).and_then(|path| {
+                authorize_existing_workspace_path(&path)
+                    .ok()
+                    .map(|(canonical_path, _)| canonical_path)
+            })
+        })
         .unwrap_or_else(default_save_dir);
 
     if fs::create_dir_all(&save_dir).is_err() {
+        return None;
+    }
+    let save_dir = canonicalize_existing_path(&save_dir).ok()?;
+    if !save_dir.is_dir() {
         return None;
     }
 
@@ -102,10 +118,20 @@ pub(crate) fn create_folder(
     preferred_dir: Option<String>,
 ) -> Option<FolderResult> {
     let target_dir = preferred_dir
-        .and_then(|value| normalize_non_empty_path(&value))
+        .and_then(|value| {
+            normalize_non_empty_path(&value).and_then(|path| {
+                authorize_existing_workspace_path(&path)
+                    .ok()
+                    .map(|(canonical_path, _)| canonical_path)
+            })
+        })
         .unwrap_or_else(default_save_dir);
 
     if fs::create_dir_all(&target_dir).is_err() {
+        return None;
+    }
+    let target_dir = canonicalize_existing_path(&target_dir).ok()?;
+    if !target_dir.is_dir() {
         return None;
     }
 
@@ -153,7 +179,49 @@ pub(crate) fn save_file(file_path: String, content: String) -> SaveResult {
         }
     };
 
-    match fs::write(normalized_path, content) {
+    let authorized_path = if normalized_path.exists() {
+        match authorize_existing_workspace_path(&normalized_path) {
+            Ok((value, _)) => value,
+            Err(error) => {
+                return SaveResult {
+                    success: false,
+                    error: Some(error),
+                };
+            }
+        }
+    } else {
+        let parent = match normalized_path.parent() {
+            Some(value) => value,
+            None => {
+                return SaveResult {
+                    success: false,
+                    error: Some("invalid-file-path".to_string()),
+                };
+            }
+        };
+
+        let scope = match authorize_existing_workspace_path(parent) {
+            Ok((_, scope)) => scope,
+            Err(error) => {
+                return SaveResult {
+                    success: false,
+                    error: Some(error),
+                };
+            }
+        };
+
+        match authorize_target_path_in_scope(&scope, &normalized_path) {
+            Ok(value) => value,
+            Err(error) => {
+                return SaveResult {
+                    success: false,
+                    error: Some(error),
+                };
+            }
+        }
+    };
+
+    match fs::write(&authorized_path, content) {
         Ok(()) => SaveResult {
             success: true,
             error: None,
@@ -167,6 +235,8 @@ pub(crate) fn save_file(file_path: String, content: String) -> SaveResult {
 
 #[tauri::command]
 pub(crate) fn load_app_state(app: tauri::AppHandle) -> AppStateWithContent {
+    register_persisted_repos(&crate::repo_commands::load_repos());
+
     let state_file = match app_state_path(&app) {
         Ok(path) => path,
         Err(_) => {
@@ -190,11 +260,15 @@ pub(crate) fn load_app_state(app: tauri::AppHandle) -> AppStateWithContent {
     let mut files: Vec<AppStateWithContentFile> = Vec::new();
     for file in state.files {
         let path = PathBuf::from(&file.path);
-        if !path.exists() || !path.is_file() {
+        let (authorized_path, _) = match authorize_existing_workspace_path(&path) {
+            Ok(value) => value,
+            Err(_) => continue,
+        };
+        if !authorized_path.exists() || !authorized_path.is_file() {
             continue;
         }
 
-        let content = match fs::read_to_string(&path) {
+        let content = match fs::read_to_string(&authorized_path) {
             Ok(value) => value,
             Err(_) => continue,
         };
@@ -202,7 +276,7 @@ pub(crate) fn load_app_state(app: tauri::AppHandle) -> AppStateWithContent {
         files.push(AppStateWithContentFile {
             id: file.id,
             name: file.name,
-            path: file.path,
+            path: authorized_path.to_string_lossy().to_string(),
             content,
         });
     }
@@ -231,7 +305,21 @@ pub(crate) fn save_app_state(app: tauri::AppHandle, state: AppState) -> SaveResu
         }
     };
 
-    match crate::write_json_file(&state_file, &state) {
+    let sanitized_state = AppState {
+        files: state
+            .files
+            .into_iter()
+            .filter(|file| {
+                normalize_non_empty_path(&file.path)
+                    .and_then(|path| authorize_existing_workspace_path(&path).ok())
+                    .is_some()
+            })
+            .collect(),
+        active_repo_id: state.active_repo_id,
+        active_file_id: state.active_file_id,
+    };
+
+    match crate::write_json_file(&state_file, &sanitized_state) {
         Ok(()) => SaveResult {
             success: true,
             error: None,
@@ -257,18 +345,33 @@ pub(crate) fn rename_file(old_path: String, new_name: String) -> OperationResult
         }
     };
 
-    let trimmed_name = new_name.trim();
-    if trimmed_name.is_empty() {
-        return OperationResult {
-            success: false,
-            new_path: None,
-            new_name: None,
-            error: Some("invalid-name".to_string()),
-        };
-    }
+    let (authorized_old_path, scope) = match authorize_existing_workspace_path(&normalized_old_path)
+    {
+        Ok(value) => value,
+        Err(error) => {
+            return OperationResult {
+                success: false,
+                new_path: None,
+                new_name: None,
+                error: Some(error),
+            };
+        }
+    };
 
-    let new_path = match normalized_old_path.parent() {
-        Some(parent) => parent.join(trimmed_name),
+    let trimmed_name = match validate_child_name(&new_name) {
+        Ok(value) => value,
+        Err(error) => {
+            return OperationResult {
+                success: false,
+                new_path: None,
+                new_name: None,
+                error: Some(error),
+            };
+        }
+    };
+
+    let new_path = match authorized_old_path.parent() {
+        Some(parent) => parent.join(&trimmed_name),
         None => {
             return OperationResult {
                 success: false,
@@ -279,16 +382,28 @@ pub(crate) fn rename_file(old_path: String, new_name: String) -> OperationResult
         }
     };
 
-    if new_path == normalized_old_path {
+    let authorized_new_path = match authorize_target_path_in_scope(&scope, &new_path) {
+        Ok(value) => value,
+        Err(error) => {
+            return OperationResult {
+                success: false,
+                new_path: None,
+                new_name: None,
+                error: Some(error),
+            };
+        }
+    };
+
+    if authorized_new_path == authorized_old_path {
         return OperationResult {
             success: true,
-            new_path: Some(new_path.to_string_lossy().to_string()),
-            new_name: Some(trimmed_name.to_string()),
+            new_path: Some(authorized_new_path.to_string_lossy().to_string()),
+            new_name: Some(trimmed_name.clone()),
             error: None,
         };
     }
 
-    if new_path.exists() {
+    if authorized_new_path.exists() {
         return OperationResult {
             success: false,
             new_path: None,
@@ -297,13 +412,16 @@ pub(crate) fn rename_file(old_path: String, new_name: String) -> OperationResult
         };
     }
 
-    match rename_path(&normalized_old_path, &new_path) {
-        Ok(()) => OperationResult {
-            success: true,
-            new_path: Some(new_path.to_string_lossy().to_string()),
-            new_name: Some(trimmed_name.to_string()),
-            error: None,
-        },
+    match rename_path(&authorized_old_path, &authorized_new_path) {
+        Ok(()) => {
+            let _ = replace_registered_exact_file(&authorized_old_path, &authorized_new_path);
+            OperationResult {
+                success: true,
+                new_path: Some(authorized_new_path.to_string_lossy().to_string()),
+                new_name: Some(trimmed_name),
+                error: None,
+            }
+        }
         Err(error) => OperationResult {
             success: false,
             new_path: None,
@@ -327,6 +445,18 @@ pub(crate) fn move_path(source_path: String, target_folder_path: String) -> Oper
         }
     };
 
+    let (source, scope) = match authorize_existing_workspace_path(&source) {
+        Ok(value) => value,
+        Err(error) => {
+            return OperationResult {
+                success: false,
+                new_path: None,
+                new_name: None,
+                error: Some(error),
+            };
+        }
+    };
+
     let target_folder = match normalize_non_empty_path(&target_folder_path) {
         Some(value) => value,
         None => {
@@ -339,23 +469,17 @@ pub(crate) fn move_path(source_path: String, target_folder_path: String) -> Oper
         }
     };
 
-    if !source.exists() {
-        return OperationResult {
-            success: false,
-            new_path: None,
-            new_name: None,
-            error: Some("source-not-found".to_string()),
-        };
-    }
-
-    if !target_folder.exists() {
-        return OperationResult {
-            success: false,
-            new_path: None,
-            new_name: None,
-            error: Some("target-not-found".to_string()),
-        };
-    }
+    let target_folder = match authorize_existing_path_in_scope(&scope, &target_folder) {
+        Ok(value) => value,
+        Err(error) => {
+            return OperationResult {
+                success: false,
+                new_path: None,
+                new_name: None,
+                error: Some(error),
+            };
+        }
+    };
 
     if !target_folder.is_dir() {
         return OperationResult {
@@ -387,6 +511,17 @@ pub(crate) fn move_path(source_path: String, target_folder_path: String) -> Oper
         .unwrap_or("moved")
         .to_string();
     let destination = target_folder.join(&source_name);
+    let destination = match authorize_target_path_in_scope(&scope, &destination) {
+        Ok(value) => value,
+        Err(error) => {
+            return OperationResult {
+                success: false,
+                new_path: None,
+                new_name: None,
+                error: Some(error),
+            };
+        }
+    };
 
     if destination == source {
         return OperationResult {
@@ -407,12 +542,15 @@ pub(crate) fn move_path(source_path: String, target_folder_path: String) -> Oper
     }
 
     match rename_path(&source, &destination) {
-        Ok(()) => OperationResult {
-            success: true,
-            new_path: Some(destination.to_string_lossy().to_string()),
-            new_name: Some(source_name),
-            error: None,
-        },
+        Ok(()) => {
+            let _ = replace_registered_exact_file(&source, &destination);
+            OperationResult {
+                success: true,
+                new_path: Some(destination.to_string_lossy().to_string()),
+                new_name: Some(source_name),
+                error: None,
+            }
+        }
         Err(error) => OperationResult {
             success: false,
             new_path: None,
@@ -434,12 +572,15 @@ pub(crate) fn reveal_in_folder(file_path: String) -> BasicResult {
         }
     };
 
-    if !normalized_path.exists() {
-        return BasicResult {
-            success: false,
-            error: Some("path-not-found".to_string()),
-        };
-    }
+    let normalized_path = match authorize_existing_workspace_path(&normalized_path) {
+        Ok((value, _)) => value,
+        Err(error) => {
+            return BasicResult {
+                success: false,
+                error: Some(error),
+            };
+        }
+    };
 
     let result = if cfg!(target_os = "macos") {
         Command::new("open")
@@ -569,6 +710,16 @@ pub(crate) fn read_file(file_path: String) -> ReadFileResponse {
         }
     };
 
+    let normalized_path = match authorize_existing_workspace_path(&normalized_path) {
+        Ok((value, _)) => value,
+        Err(error) => {
+            return ReadFileResponse {
+                content: String::new(),
+                error: Some(error),
+            };
+        }
+    };
+
     match fs::read_to_string(normalized_path) {
         Ok(content) => ReadFileResponse {
             content,
@@ -589,6 +740,16 @@ pub(crate) fn read_file_bytes(file_path: String) -> ReadFileBytesResponse {
             return ReadFileBytesResponse {
                 data: None,
                 error: Some("invalid-file-path".to_string()),
+            };
+        }
+    };
+
+    let normalized_path = match authorize_existing_workspace_path(&normalized_path) {
+        Ok((value, _)) => value,
+        Err(error) => {
+            return ReadFileBytesResponse {
+                data: None,
+                error: Some(error),
             };
         }
     };

--- a/src-tauri/src/git_commands.rs
+++ b/src-tauri/src/git_commands.rs
@@ -4,8 +4,9 @@ use std::path::Path;
 use std::process::Command;
 
 use crate::{
-    normalize_non_empty_path, now_ms, to_error, BasicResult, GitChangeEntry, GitCommandOutput,
-    GitDiffResponse, GitDiffResult, GitStatusResponse, GitStatusSummary,
+    authorize_workspace_root, normalize_non_empty_path, now_ms, to_error,
+    validate_repo_relative_path, BasicResult, GitChangeEntry, GitCommandOutput, GitDiffResponse,
+    GitDiffResult, GitStatusResponse, GitStatusSummary,
 };
 
 pub(crate) fn format_git_error(output: &GitCommandOutput) -> String {
@@ -334,6 +335,16 @@ pub(crate) fn get_git_status(repo_path: String) -> GitStatusResponse {
             };
         }
     };
+    let normalized_repo_path = match authorize_workspace_root(&normalized_repo_path) {
+        Ok(value) => value,
+        Err(error) => {
+            return GitStatusResponse {
+                success: false,
+                data: None,
+                error: Some(error),
+            };
+        }
+    };
 
     if !normalized_repo_path.exists() {
         return GitStatusResponse {
@@ -386,8 +397,28 @@ pub(crate) fn get_git_diff(repo_path: String, file_path: String, group: String) 
             };
         }
     };
+    let normalized_repo_path = match authorize_workspace_root(&normalized_repo_path) {
+        Ok(value) => value,
+        Err(error) => {
+            return GitDiffResponse {
+                success: false,
+                data: None,
+                error: Some(error),
+            };
+        }
+    };
 
-    let normalized_file_path = file_path.trim();
+    let normalized_file_path = match validate_repo_relative_path(&file_path) {
+        Ok(value) => value,
+        Err(error) => {
+            return GitDiffResponse {
+                success: false,
+                data: None,
+                error: Some(error),
+            };
+        }
+    };
+
     if normalized_file_path.is_empty() {
         return GitDiffResponse {
             success: false,
@@ -405,7 +436,7 @@ pub(crate) fn get_git_diff(repo_path: String, file_path: String, group: String) 
     }
 
     if group == "untracked" {
-        return match build_untracked_patch(&normalized_repo_path, normalized_file_path) {
+        return match build_untracked_patch(&normalized_repo_path, &normalized_file_path) {
             Ok(result) => GitDiffResponse {
                 success: true,
                 data: Some(result),
@@ -427,7 +458,7 @@ pub(crate) fn get_git_diff(repo_path: String, file_path: String, group: String) 
             "--staged",
             "--binary",
             "--",
-            normalized_file_path,
+            normalized_file_path.as_str(),
         ]
     } else {
         vec![
@@ -436,7 +467,7 @@ pub(crate) fn get_git_diff(repo_path: String, file_path: String, group: String) 
             "diff",
             "--binary",
             "--",
-            normalized_file_path,
+            normalized_file_path.as_str(),
         ]
     };
 
@@ -450,7 +481,7 @@ pub(crate) fn get_git_diff(repo_path: String, file_path: String, group: String) 
             GitDiffResponse {
                 success: true,
                 data: Some(GitDiffResult {
-                    path: normalized_file_path.to_string(),
+                    path: normalized_file_path,
                     group,
                     mode: if binary {
                         "binary".to_string()
@@ -492,8 +523,26 @@ pub(crate) fn stage_git_file(repo_path: String, file_path: String) -> BasicResul
             };
         }
     };
+    let normalized_repo_path = match authorize_workspace_root(&normalized_repo_path) {
+        Ok(value) => value,
+        Err(error) => {
+            return BasicResult {
+                success: false,
+                error: Some(error),
+            };
+        }
+    };
 
-    let normalized_path = file_path.trim().to_string();
+    let normalized_path = match validate_repo_relative_path(&file_path) {
+        Ok(value) => value,
+        Err(error) => {
+            return BasicResult {
+                success: false,
+                error: Some(error),
+            };
+        }
+    };
+
     if normalized_path.is_empty() {
         return BasicResult {
             success: false,
@@ -534,8 +583,26 @@ pub(crate) fn unstage_git_file(repo_path: String, file_path: String) -> BasicRes
             };
         }
     };
+    let normalized_repo_path = match authorize_workspace_root(&normalized_repo_path) {
+        Ok(value) => value,
+        Err(error) => {
+            return BasicResult {
+                success: false,
+                error: Some(error),
+            };
+        }
+    };
 
-    let normalized_path = file_path.trim().to_string();
+    let normalized_path = match validate_repo_relative_path(&file_path) {
+        Ok(value) => value,
+        Err(error) => {
+            return BasicResult {
+                success: false,
+                error: Some(error),
+            };
+        }
+    };
+
     if normalized_path.is_empty() {
         return BasicResult {
             success: false,
@@ -611,6 +678,15 @@ pub(crate) fn stage_all_git_changes(repo_path: String) -> BasicResult {
             };
         }
     };
+    let normalized_repo_path = match authorize_workspace_root(&normalized_repo_path) {
+        Ok(value) => value,
+        Err(error) => {
+            return BasicResult {
+                success: false,
+                error: Some(error),
+            };
+        }
+    };
 
     if let Err(error) = assert_git_repository(&normalized_repo_path) {
         return BasicResult {
@@ -639,6 +715,15 @@ pub(crate) fn sync_git_pull(repo_path: String, remote_name: Option<String>) -> B
             return BasicResult {
                 success: false,
                 error: Some("invalid-repo-path".to_string()),
+            };
+        }
+    };
+    let normalized_repo_path = match authorize_workspace_root(&normalized_repo_path) {
+        Ok(value) => value,
+        Err(error) => {
+            return BasicResult {
+                success: false,
+                error: Some(error),
             };
         }
     };
@@ -679,6 +764,15 @@ pub(crate) fn commit_git_changes(repo_path: String, message: String) -> BasicRes
             return BasicResult {
                 success: false,
                 error: Some("invalid-repo-path".to_string()),
+            };
+        }
+    };
+    let normalized_repo_path = match authorize_workspace_root(&normalized_repo_path) {
+        Ok(value) => value,
+        Err(error) => {
+            return BasicResult {
+                success: false,
+                error: Some(error),
             };
         }
     };

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,216 +8,340 @@ mod support;
 mod updater_commands;
 
 use fs_commands::{
-	create_file, create_folder, load_app_state, move_path, open_external, open_file,
-	read_asset, read_file, read_file_bytes, rename_file, reveal_in_folder, save_app_state,
-	save_file, select_folder,
+    create_file, create_folder, load_app_state, move_path, open_external, open_file, read_asset,
+    read_file, read_file_bytes, rename_file, reveal_in_folder, save_app_state, save_file,
+    select_folder,
 };
 use git_commands::{
-	commit_git_changes, get_git_diff, get_git_status, stage_all_git_changes, stage_git_file,
-	sync_git_pull, unstage_git_file,
+    commit_git_changes, get_git_diff, get_git_status, stage_all_git_changes, stage_git_file,
+    sync_git_pull, unstage_git_file,
 };
 pub(crate) use models::*;
 use power_commands::set_keep_awake;
-use repo_commands::{
-	delete_file, load_repos, load_workspace_metadata, save_repos, save_workspace_metadata,
-	scan_directory, start_repo_watch, stop_repo_watch,
-};
 #[cfg(test)]
 pub(crate) use repo_commands::{create_repo_watcher, map_notify_event_type};
+use repo_commands::{
+    delete_file, load_repos, load_workspace_metadata, save_repos, save_workspace_metadata,
+    scan_directory, start_repo_watch, stop_repo_watch,
+};
 use settings_commands::{load_global_settings, save_global_settings};
 pub(crate) use support::*;
 use updater_commands::{check_for_updates, fetch_releases_feed, get_app_version, install_update};
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-	with_optional_updater_plugin(tauri::Builder::default())
-		.manage(RepoWatchManager::default())
-		.manage(KeepAwakeManager::default())
-		.invoke_handler(tauri::generate_handler![
-			open_file,
-			select_folder,
-			create_file,
-			create_folder,
-			save_file,
-			load_app_state,
-			save_app_state,
-			rename_file,
-			move_path,
-			reveal_in_folder,
-			open_external,
-			read_asset,
-			read_file,
-			read_file_bytes,
-			scan_directory,
-			load_repos,
-			save_repos,
-			load_workspace_metadata,
-			save_workspace_metadata,
-			delete_file,
-			start_repo_watch,
-			stop_repo_watch,
-			get_git_status,
-			get_git_diff,
-			stage_git_file,
-			stage_all_git_changes,
-			unstage_git_file,
-			sync_git_pull,
-			commit_git_changes,
-			check_for_updates,
-			install_update,
-			get_app_version,
-			fetch_releases_feed,
-			load_global_settings,
-			save_global_settings,
-			set_keep_awake
-		])
-		.run(tauri::generate_context!())
-		.expect("error while running tauri application");
+    with_optional_updater_plugin(tauri::Builder::default())
+        .manage(RepoWatchManager::default())
+        .manage(KeepAwakeManager::default())
+        .invoke_handler(tauri::generate_handler![
+            open_file,
+            select_folder,
+            create_file,
+            create_folder,
+            save_file,
+            load_app_state,
+            save_app_state,
+            rename_file,
+            move_path,
+            reveal_in_folder,
+            open_external,
+            read_asset,
+            read_file,
+            read_file_bytes,
+            scan_directory,
+            load_repos,
+            save_repos,
+            load_workspace_metadata,
+            save_workspace_metadata,
+            delete_file,
+            start_repo_watch,
+            stop_repo_watch,
+            get_git_status,
+            get_git_diff,
+            stage_git_file,
+            stage_all_git_changes,
+            unstage_git_file,
+            sync_git_pull,
+            commit_git_changes,
+            check_for_updates,
+            install_update,
+            get_app_version,
+            fetch_releases_feed,
+            load_global_settings,
+            save_global_settings,
+            set_keep_awake
+        ])
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
 }
 
 #[cfg(not(debug_assertions))]
 fn with_optional_updater_plugin(builder: tauri::Builder<tauri::Wry>) -> tauri::Builder<tauri::Wry> {
-	builder.plugin(tauri_plugin_updater::Builder::new().build())
+    builder.plugin(tauri_plugin_updater::Builder::new().build())
 }
 
 #[cfg(debug_assertions)]
 fn with_optional_updater_plugin(builder: tauri::Builder<tauri::Wry>) -> tauri::Builder<tauri::Wry> {
-	builder
+    builder
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
-	use notify::event::{CreateKind, DataChange, EventKind, ModifyKind, RemoveKind};
-	use serde_json::json;
-	use std::fs;
-	use std::path::PathBuf;
-	use std::sync::mpsc;
-	use std::time::{Duration, Instant};
+    use super::*;
+    use notify::event::{CreateKind, DataChange, EventKind, ModifyKind, RemoveKind};
+    use serde_json::json;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::process::Command;
+    use std::sync::mpsc;
+    use std::time::{Duration, Instant};
 
-	fn temp_dir_for(test_name: &str) -> PathBuf {
-		let mut dir = std::env::temp_dir();
-		dir.push(format!(
-			"tabst-tauri-parity-{}-{}-{}",
-			test_name,
-			std::process::id(),
-			now_ms()
-		));
-		fs::create_dir_all(&dir).expect("failed to create temp test directory");
-		dir
-	}
+    fn temp_dir_for(test_name: &str) -> PathBuf {
+        let mut dir = std::env::temp_dir();
+        dir.push(format!(
+            "tabst-tauri-parity-{}-{}-{}",
+            test_name,
+            std::process::id(),
+            now_ms()
+        ));
+        fs::create_dir_all(&dir).expect("failed to create temp test directory");
+        dir
+    }
 
-	#[test]
-	fn update_support_matrix_matches_tauri_release_policy() {
-		assert!(is_update_supported_runtime("macos", false));
-		assert!(is_update_supported_runtime("linux", false));
-		assert!(is_update_supported_runtime("windows", false));
-		assert!(!is_update_supported_runtime("windows", true));
-		assert!(!is_update_supported_runtime("linux", true));
-		assert!(!is_update_supported_runtime("macos", true));
-	}
+    fn init_git_repo(dir: &PathBuf) {
+        let status = Command::new("git")
+            .arg("init")
+            .current_dir(dir)
+            .status()
+            .expect("failed to run git init");
+        assert!(status.success(), "git init should succeed in test repo");
+    }
 
-	#[test]
-	fn notify_kind_mapping_matches_legacy_watch_contract() {
-		assert_eq!(map_notify_event_type(&EventKind::Create(CreateKind::Any)), "rename");
-		assert_eq!(
-			map_notify_event_type(&EventKind::Modify(ModifyKind::Data(DataChange::Any))),
-			"change"
-		);
-		assert_eq!(map_notify_event_type(&EventKind::Remove(RemoveKind::Any)), "rename");
-	}
+    #[test]
+    fn update_support_matrix_matches_tauri_release_policy() {
+        assert!(is_update_supported_runtime("macos", false));
+        assert!(is_update_supported_runtime("linux", false));
+        assert!(is_update_supported_runtime("windows", false));
+        assert!(!is_update_supported_runtime("windows", true));
+        assert!(!is_update_supported_runtime("linux", true));
+        assert!(!is_update_supported_runtime("macos", true));
+    }
 
-	#[test]
-	fn asset_path_aliases_include_root_docs_files() {
-		assert_eq!(
-			asset_virtual_path_candidates("docs/README.md"),
-			vec!["docs/README.md".to_string(), "README.md".to_string()]
-		);
-		assert_eq!(
-			asset_virtual_path_candidates("docs/ROADMAP.md"),
-			vec!["docs/ROADMAP.md".to_string(), "ROADMAP.md".to_string()]
-		);
-		assert_eq!(
-			asset_virtual_path_candidates("docs/dev/README.md"),
-			vec!["docs/dev/README.md".to_string()]
-		);
-	}
+    #[test]
+    fn notify_kind_mapping_matches_legacy_watch_contract() {
+        assert_eq!(
+            map_notify_event_type(&EventKind::Create(CreateKind::Any)),
+            "rename"
+        );
+        assert_eq!(
+            map_notify_event_type(&EventKind::Modify(ModifyKind::Data(DataChange::Any))),
+            "change"
+        );
+        assert_eq!(
+            map_notify_event_type(&EventKind::Remove(RemoveKind::Any)),
+            "rename"
+        );
+    }
 
-	#[test]
-	fn repo_metadata_roundtrip_preserves_workspace_session_fields() {
-		let original = RepoMetadata {
-			id: "repo-1".to_string(),
-			name: "Workspace".to_string(),
-			opened_at: 100,
-			expanded_folders: vec!["/tmp/workspace/docs".to_string()],
-			preferences: Some(json!({
-				"locale": "en",
-				"deleteBehavior": "repo-trash",
-				"theme": {
-					"uiThemeId": "github",
-					"editorThemeId": "github",
-					"mode": "dark"
-				}
-			})),
-			active_file_path: Some("/tmp/workspace/song.atex".to_string()),
-			workspace_mode: Some("editor".to_string()),
-			active_settings_page_id: Some("playback".to_string()),
-			active_tutorial_id: Some("user-readme".to_string()),
-			tutorial_audience: Some("user".to_string()),
-		};
+    #[test]
+    fn asset_path_aliases_include_root_docs_files() {
+        assert_eq!(
+            asset_virtual_path_candidates("docs/README.md"),
+            vec!["docs/README.md".to_string(), "README.md".to_string()]
+        );
+        assert_eq!(
+            asset_virtual_path_candidates("docs/ROADMAP.md"),
+            vec!["docs/ROADMAP.md".to_string(), "ROADMAP.md".to_string()]
+        );
+        assert_eq!(
+            asset_virtual_path_candidates("docs/dev/README.md"),
+            vec!["docs/dev/README.md".to_string()]
+        );
+    }
 
-		let encoded = serde_json::to_string(&original).expect("encode repo metadata");
-		let decoded: RepoMetadata = serde_json::from_str(&encoded).expect("decode repo metadata");
+    #[test]
+    fn repo_metadata_roundtrip_preserves_workspace_session_fields() {
+        let original = RepoMetadata {
+            id: "repo-1".to_string(),
+            name: "Workspace".to_string(),
+            opened_at: 100,
+            expanded_folders: vec!["/tmp/workspace/docs".to_string()],
+            preferences: Some(json!({
+                "locale": "en",
+                "deleteBehavior": "repo-trash",
+                "theme": {
+                    "uiThemeId": "github",
+                    "editorThemeId": "github",
+                    "mode": "dark"
+                }
+            })),
+            active_file_path: Some("/tmp/workspace/song.atex".to_string()),
+            workspace_mode: Some("editor".to_string()),
+            active_settings_page_id: Some("playback".to_string()),
+            active_tutorial_id: Some("user-readme".to_string()),
+            tutorial_audience: Some("user".to_string()),
+        };
 
-		assert_eq!(decoded.active_file_path, original.active_file_path);
-		assert_eq!(decoded.workspace_mode, original.workspace_mode);
-		assert_eq!(
-			decoded.active_settings_page_id,
-			original.active_settings_page_id
-		);
-		assert_eq!(decoded.active_tutorial_id, original.active_tutorial_id);
-		assert_eq!(decoded.tutorial_audience, original.tutorial_audience);
-	}
+        let encoded = serde_json::to_string(&original).expect("encode repo metadata");
+        let decoded: RepoMetadata = serde_json::from_str(&encoded).expect("decode repo metadata");
 
-	#[test]
-	fn repo_watcher_emits_events_for_fs_changes() {
-		let repo_dir = temp_dir_for("repo-watch");
-		let watched_file = repo_dir.join("watched.atex");
+        assert_eq!(decoded.active_file_path, original.active_file_path);
+        assert_eq!(decoded.workspace_mode, original.workspace_mode);
+        assert_eq!(
+            decoded.active_settings_page_id,
+            original.active_settings_page_id
+        );
+        assert_eq!(decoded.active_tutorial_id, original.active_tutorial_id);
+        assert_eq!(decoded.tutorial_audience, original.tutorial_audience);
+    }
 
-		let (tx, rx) = mpsc::channel::<RepoFsChangedEvent>();
-		let watcher = create_repo_watcher(repo_dir.clone(), move |event| {
-			let _ = tx.send(event);
-		})
-		.expect("failed to create watcher");
+    #[test]
+    fn repo_watcher_emits_events_for_fs_changes() {
+        let repo_dir = temp_dir_for("repo-watch");
+        let watched_file = repo_dir.join("watched.atex");
 
-		fs::write(&watched_file, "sync").expect("failed to write watched file");
+        let (tx, rx) = mpsc::channel::<RepoFsChangedEvent>();
+        let watcher = create_repo_watcher(repo_dir.clone(), move |event| {
+            let _ = tx.send(event);
+        })
+        .expect("failed to create watcher");
 
-		let deadline = Instant::now() + Duration::from_secs(5);
-		let mut seen = false;
+        fs::write(&watched_file, "sync").expect("failed to write watched file");
 
-		while Instant::now() < deadline {
-			match rx.recv_timeout(Duration::from_millis(250)) {
-				Ok(event) => {
-					let is_expected_type =
-						event.event_type == "rename" || event.event_type == "change";
-					let is_expected_path = event
-						.changed_path
-						.as_deref()
-						.map(|value| value.ends_with("watched.atex"))
-						.unwrap_or(false);
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut seen = false;
 
-					if is_expected_type && is_expected_path {
-						seen = true;
-						break;
-					}
-				}
-				Err(mpsc::RecvTimeoutError::Timeout) => continue,
-				Err(mpsc::RecvTimeoutError::Disconnected) => break,
-			}
-		}
+        while Instant::now() < deadline {
+            match rx.recv_timeout(Duration::from_millis(250)) {
+                Ok(event) => {
+                    let is_expected_type =
+                        event.event_type == "rename" || event.event_type == "change";
+                    let is_expected_path = event
+                        .changed_path
+                        .as_deref()
+                        .map(|value| value.ends_with("watched.atex"))
+                        .unwrap_or(false);
 
-		drop(watcher);
-		let _ = fs::remove_dir_all(&repo_dir);
-		assert!(seen, "expected repo watcher to emit at least one fs change event");
-	}
+                    if is_expected_type && is_expected_path {
+                        seen = true;
+                        break;
+                    }
+                }
+                Err(mpsc::RecvTimeoutError::Timeout) => continue,
+                Err(mpsc::RecvTimeoutError::Disconnected) => break,
+            }
+        }
+
+        drop(watcher);
+        let _ = fs::remove_dir_all(&repo_dir);
+        assert!(
+            seen,
+            "expected repo watcher to emit at least one fs change event"
+        );
+    }
+
+    #[test]
+    fn rename_file_rejects_names_that_escape_the_parent_directory() {
+        let repo_dir = temp_dir_for("rename-scope");
+        let nested_dir = repo_dir.join("nested");
+        fs::create_dir_all(&nested_dir).expect("failed to create nested dir");
+        let source_path = nested_dir.join("song.atex");
+        fs::write(&source_path, "content").expect("failed to write source file");
+
+        let result = rename_file(
+            source_path.to_string_lossy().to_string(),
+            "../escaped.atex".to_string(),
+        );
+
+        assert!(
+            !result.success,
+            "expected rename to reject parent-directory escape"
+        );
+        assert_eq!(result.error.as_deref(), Some("path-outside-workspace"));
+        assert!(
+            !repo_dir.join("escaped.atex").exists(),
+            "rename should not create a file outside the original parent directory"
+        );
+
+        let _ = fs::remove_dir_all(&repo_dir);
+    }
+
+    #[test]
+    fn move_path_rejects_cross_workspace_moves() {
+        let repo_dir = temp_dir_for("move-scope-repo");
+        let outside_dir = temp_dir_for("move-scope-outside");
+        let source_path = repo_dir.join("song.atex");
+        fs::write(&source_path, "content").expect("failed to write source file");
+
+        let result = move_path(
+            source_path.to_string_lossy().to_string(),
+            outside_dir.to_string_lossy().to_string(),
+        );
+
+        assert!(
+            !result.success,
+            "expected move_path to reject moving files outside the workspace root"
+        );
+        assert_eq!(result.error.as_deref(), Some("path-outside-workspace"));
+        assert!(
+            source_path.exists(),
+            "source file should remain in place after a rejected move"
+        );
+
+        let _ = fs::remove_dir_all(&repo_dir);
+        let _ = fs::remove_dir_all(&outside_dir);
+    }
+
+    #[test]
+    fn delete_file_repo_trash_rejects_paths_outside_the_repo_root() {
+        let repo_dir = temp_dir_for("delete-scope-repo");
+        let outside_dir = temp_dir_for("delete-scope-outside");
+        let outside_file = outside_dir.join("outside.atex");
+        fs::write(&outside_file, "content").expect("failed to write outside file");
+
+        let result = delete_file(
+            outside_file.to_string_lossy().to_string(),
+            "repo-trash".to_string(),
+            Some(repo_dir.to_string_lossy().to_string()),
+        );
+
+        assert!(
+            !result.success,
+            "expected repo-trash deletion to reject files outside the repo root"
+        );
+        assert_eq!(result.error.as_deref(), Some("path-outside-workspace"));
+        assert!(
+            outside_file.exists(),
+            "outside file should remain in place after a rejected delete"
+        );
+
+        let _ = fs::remove_dir_all(&repo_dir);
+        let _ = fs::remove_dir_all(&outside_dir);
+    }
+
+    #[test]
+    fn stage_git_file_rejects_parent_directory_pathspecs() {
+        let repo_dir = temp_dir_for("git-pathspec-scope");
+        init_git_repo(&repo_dir);
+        register_allowed_root(&repo_dir).expect("failed to register allowed repo root");
+        let outside_file = repo_dir
+            .parent()
+            .expect("repo temp dir should have a parent")
+            .join(format!("outside-{}.atex", now_ms()));
+        fs::write(&outside_file, "content").expect("failed to write outside file");
+
+        let result = stage_git_file(
+            repo_dir.to_string_lossy().to_string(),
+            format!("../{}", outside_file.file_name().unwrap().to_string_lossy()),
+        );
+
+        assert!(
+            !result.success,
+            "expected git staging to reject parent-directory pathspecs"
+        );
+        assert_eq!(result.error.as_deref(), Some("invalid-file-path"));
+
+        let _ = fs::remove_file(&outside_file);
+        let _ = fs::remove_dir_all(&repo_dir);
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -97,6 +97,7 @@ mod tests {
     use std::sync::mpsc;
     use std::sync::{Mutex, OnceLock};
     use std::time::{Duration, Instant};
+    use tauri::test::mock_app;
 
     fn temp_dir_for(test_name: &str) -> PathBuf {
         let mut dir = std::env::temp_dir();
@@ -488,5 +489,90 @@ mod tests {
         assert_eq!(read_result.content, "content");
 
         let _ = fs::remove_dir_all(&standalone_dir);
+    }
+
+    #[test]
+    fn load_app_state_restores_standalone_files_from_previous_session() {
+        with_temp_home("load-app-state-standalone", |_home_dir| {
+            let standalone_dir = temp_dir_for("standalone-session");
+            let standalone_path = standalone_dir.join("standalone.atex");
+            fs::write(&standalone_path, "content").expect("write standalone session file");
+
+            let app = mock_app();
+            let app_handle = app.handle().clone();
+            let state_path = app_state_path(&app_handle).expect("app state path");
+            let _ = fs::remove_file(&state_path);
+
+            write_json_file(
+                &state_path,
+                &AppState {
+                    files: vec![AppStateFile {
+                        id: "file-1".to_string(),
+                        name: "standalone.atex".to_string(),
+                        path: standalone_path.to_string_lossy().to_string(),
+                    }],
+                    active_repo_id: None,
+                    active_file_id: Some("file-1".to_string()),
+                },
+            )
+            .expect("write app state");
+
+            let loaded = fs_commands::load_app_state_with_handle(&app_handle);
+
+            assert_eq!(
+                loaded.files.len(),
+                1,
+                "standalone files restored from app state should survive app restart"
+            );
+            assert_eq!(loaded.files[0].content, "content");
+            assert_eq!(
+                loaded.files[0].path,
+                fs::canonicalize(&standalone_path)
+                    .expect("canonical standalone path")
+                    .to_string_lossy()
+                    .to_string()
+            );
+            assert_eq!(loaded.active_file_id.as_deref(), Some("file-1"));
+
+            let _ = fs::remove_file(&state_path);
+            let _ = fs::remove_dir_all(&standalone_dir);
+        });
+    }
+
+    #[test]
+    fn authorize_workspace_root_re_registers_persisted_repos_after_reconnect() {
+        with_temp_home("persisted-repo-reconnect", |_home_dir| {
+            let repo_dir = temp_dir_for("reconnect-repo");
+            fs::create_dir_all(&repo_dir).expect("create repo dir");
+
+            let metadata_dir = global_metadata_dir().expect("global metadata dir");
+            let repos_path = metadata_dir.join("repos.json");
+            write_json_file(
+                &repos_path,
+                &vec![Repo {
+                    id: "repo-1".to_string(),
+                    name: "Reconnect Repo".to_string(),
+                    path: repo_dir.to_string_lossy().to_string(),
+                    last_opened_at: 1,
+                }],
+            )
+            .expect("write repos");
+
+            fs::remove_dir_all(&repo_dir).expect("remove repo to simulate disconnected drive");
+
+            let loaded = load_repos();
+            assert_eq!(loaded.len(), 1, "offline repo should still be listed");
+
+            fs::create_dir_all(&repo_dir).expect("recreate repo after reconnect");
+
+            let authorized = authorize_workspace_root(&repo_dir)
+                .expect("persisted repo should re-register once it comes back online");
+            assert_eq!(
+                authorized,
+                fs::canonicalize(&repo_dir).expect("canonical repo path after reconnect")
+            );
+
+            let _ = fs::remove_dir_all(&repo_dir);
+        });
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -90,10 +90,12 @@ mod tests {
     use super::*;
     use notify::event::{CreateKind, DataChange, EventKind, ModifyKind, RemoveKind};
     use serde_json::json;
+    use std::env;
     use std::fs;
     use std::path::PathBuf;
     use std::process::Command;
     use std::sync::mpsc;
+    use std::sync::{Mutex, OnceLock};
     use std::time::{Duration, Instant};
 
     fn temp_dir_for(test_name: &str) -> PathBuf {
@@ -115,6 +117,35 @@ mod tests {
             .status()
             .expect("failed to run git init");
         assert!(status.success(), "git init should succeed in test repo");
+    }
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn with_temp_home<T>(test_name: &str, run: impl FnOnce(PathBuf) -> T) -> T {
+        let _guard = env_lock().lock().expect("failed to lock env mutex");
+        let home_dir = temp_dir_for(test_name);
+        let previous_home = env::var_os("HOME");
+
+        unsafe {
+            env::set_var("HOME", &home_dir);
+        }
+
+        let result = run(home_dir.clone());
+
+        match previous_home {
+            Some(value) => unsafe {
+                env::set_var("HOME", value);
+            },
+            None => unsafe {
+                env::remove_var("HOME");
+            },
+        }
+
+        let _ = fs::remove_dir_all(&home_dir);
+        result
     }
 
     #[test]
@@ -343,5 +374,119 @@ mod tests {
 
         let _ = fs::remove_file(&outside_file);
         let _ = fs::remove_dir_all(&repo_dir);
+    }
+
+    #[test]
+    fn save_repos_preserves_temporarily_unavailable_entries() {
+        with_temp_home("save-repos-preserve-unavailable", |_home_dir| {
+            let repo_one_dir = temp_dir_for("saved-repo-one");
+            let repo_two_dir = temp_dir_for("saved-repo-two");
+            register_allowed_root(&repo_one_dir).expect("register repo one");
+            register_allowed_root(&repo_two_dir).expect("register repo two");
+
+            let repo_one = Repo {
+                id: "repo-1".to_string(),
+                name: "Repo One".to_string(),
+                path: repo_one_dir.to_string_lossy().to_string(),
+                last_opened_at: 1,
+            };
+            let repo_two = Repo {
+                id: "repo-2".to_string(),
+                name: "Repo Two".to_string(),
+                path: repo_two_dir.to_string_lossy().to_string(),
+                last_opened_at: 2,
+            };
+
+            save_repos(vec![repo_one.clone(), repo_two.clone()]);
+
+            fs::remove_dir_all(&repo_one_dir).expect("remove repo one to simulate offline repo");
+
+            save_repos(vec![
+                Repo {
+                    last_opened_at: 10,
+                    ..repo_one.clone()
+                },
+                Repo {
+                    last_opened_at: 20,
+                    ..repo_two.clone()
+                },
+            ]);
+
+            let persisted = load_repos();
+            assert_eq!(
+                persisted.len(),
+                2,
+                "saving repos should not drop previously known repos that are temporarily unavailable"
+            );
+            assert!(
+                persisted.iter().any(|repo| repo.id == repo_one.id),
+                "offline repo entry should still be present after save"
+            );
+
+            let _ = fs::remove_dir_all(&repo_two_dir);
+        });
+    }
+
+    #[test]
+    fn load_repos_returns_canonical_paths_for_accessible_entries() {
+        with_temp_home("load-repos-canonical-paths", |_home_dir| {
+            let repo_parent = temp_dir_for("canonical-repo-parent");
+            let alias_dir = repo_parent.join("alias");
+            let repo_dir = repo_parent.join("repo");
+            fs::create_dir_all(&alias_dir).expect("create alias dir");
+            fs::create_dir_all(&repo_dir).expect("create repo dir");
+
+            let alias_path = alias_dir.join("..").join("repo");
+            let metadata_dir = global_metadata_dir().expect("global metadata dir");
+            let repos_path = metadata_dir.join("repos.json");
+            write_json_file(
+                &repos_path,
+                &vec![Repo {
+                    id: "repo-1".to_string(),
+                    name: "Repo".to_string(),
+                    path: alias_path.to_string_lossy().to_string(),
+                    last_opened_at: 1,
+                }],
+            )
+            .expect("write repos");
+
+            let loaded = load_repos();
+            assert_eq!(loaded.len(), 1);
+            assert_eq!(
+                loaded[0].path,
+                fs::canonicalize(&repo_dir)
+                    .expect("canonical repo path")
+                    .to_string_lossy()
+                    .to_string()
+            );
+
+            let _ = fs::remove_dir_all(&repo_parent);
+        });
+    }
+
+    #[test]
+    fn rename_file_keeps_exact_file_registration_in_sync() {
+        let standalone_dir = temp_dir_for("exact-file-rename");
+        let source_path = standalone_dir.join("standalone.atex");
+        fs::write(&source_path, "content").expect("write standalone file");
+        register_allowed_file(&source_path).expect("register standalone file");
+
+        let result = rename_file(
+            source_path.to_string_lossy().to_string(),
+            "renamed.atex".to_string(),
+        );
+
+        assert!(result.success, "expected standalone rename to succeed");
+        let new_path = PathBuf::from(
+            result
+                .new_path
+                .clone()
+                .expect("rename should return new path for standalone file"),
+        );
+        let read_result = read_file(new_path.to_string_lossy().to_string());
+        assert_eq!(read_result.error, None);
+        assert_eq!(read_result.content, "content");
+
+        let _ = fs::remove_dir_all(&standalone_dir);
     }
 }

--- a/src-tauri/src/repo_commands.rs
+++ b/src-tauri/src/repo_commands.rs
@@ -9,8 +9,8 @@ use tauri::Emitter;
 
 use crate::{
     authorize_existing_workspace_path, authorize_workspace_root, global_metadata_dir,
-    normalize_non_empty_path, now_ms, path_is_within_root, read_json_file,
-    register_persisted_repos, rename_path, sanitize_repos_for_persistence, to_error,
+    normalize_loaded_repos, normalize_non_empty_path, now_ms, path_is_within_root,
+    prepare_repos_for_persistence, read_json_file, register_persisted_repos, rename_path, to_error,
     unregister_allowed_path, write_json_file, BasicResult, BasicSuccess, FileNode, Repo,
     RepoFsChangedEvent, RepoMetadata, RepoWatchManager, RepoWatcherState, ScanDirectoryResult,
 };
@@ -168,16 +168,22 @@ pub(crate) fn scan_directory(dir_path: String) -> Option<ScanDirectoryResult> {
 
 #[tauri::command]
 pub(crate) fn load_repos() -> Vec<Repo> {
+    load_repos_from_storage()
+}
+
+pub(crate) fn load_repos_from_storage() -> Vec<Repo> {
     let metadata_dir = match global_metadata_dir() {
         Ok(value) => value,
         Err(_) => return Vec::new(),
     };
     let repos_path = metadata_dir.join("repos.json");
 
-    let repos = read_json_file::<Vec<Repo>>(&repos_path)
-        .ok()
-        .flatten()
-        .unwrap_or_default();
+    let repos = normalize_loaded_repos(
+        read_json_file::<Vec<Repo>>(&repos_path)
+            .ok()
+            .flatten()
+            .unwrap_or_default(),
+    );
     register_persisted_repos(&repos);
     repos
 }
@@ -186,8 +192,9 @@ pub(crate) fn load_repos() -> Vec<Repo> {
 pub(crate) fn save_repos(repos: Vec<Repo>) {
     if let Ok(metadata_dir) = global_metadata_dir() {
         let repos_path = metadata_dir.join("repos.json");
-        let sanitized = sanitize_repos_for_persistence(repos);
-        let _ = write_json_file(&repos_path, &sanitized);
+        let existing = load_repos_from_storage();
+        let prepared = prepare_repos_for_persistence(&existing, repos);
+        let _ = write_json_file(&repos_path, &prepared);
     }
 }
 

--- a/src-tauri/src/repo_commands.rs
+++ b/src-tauri/src/repo_commands.rs
@@ -8,9 +8,11 @@ use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use tauri::Emitter;
 
 use crate::{
-    global_metadata_dir, normalize_non_empty_path, now_ms, read_json_file, rename_path, to_error,
-    write_json_file, BasicResult, BasicSuccess, FileNode, Repo, RepoFsChangedEvent, RepoMetadata,
-    RepoWatchManager, RepoWatcherState, ScanDirectoryResult,
+    authorize_existing_workspace_path, authorize_workspace_root, global_metadata_dir,
+    normalize_non_empty_path, now_ms, path_is_within_root, read_json_file,
+    register_persisted_repos, rename_path, sanitize_repos_for_persistence, to_error,
+    unregister_allowed_path, write_json_file, BasicResult, BasicSuccess, FileNode, Repo,
+    RepoFsChangedEvent, RepoMetadata, RepoWatchManager, RepoWatcherState, ScanDirectoryResult,
 };
 
 const SUPPORTED_EXTENSIONS: [&str; 7] = [".md", ".atex", ".gp", ".gp3", ".gp4", ".gp5", ".gpx"];
@@ -155,6 +157,7 @@ fn scan_directory_recursive(dir_path: &Path) -> Result<Vec<FileNode>, String> {
 #[tauri::command]
 pub(crate) fn scan_directory(dir_path: String) -> Option<ScanDirectoryResult> {
     let normalized_path = normalize_non_empty_path(&dir_path)?;
+    let normalized_path = authorize_workspace_root(&normalized_path).ok()?;
     let nodes = scan_directory_recursive(&normalized_path).ok()?;
 
     Some(ScanDirectoryResult {
@@ -171,23 +174,27 @@ pub(crate) fn load_repos() -> Vec<Repo> {
     };
     let repos_path = metadata_dir.join("repos.json");
 
-    read_json_file::<Vec<Repo>>(&repos_path)
+    let repos = read_json_file::<Vec<Repo>>(&repos_path)
         .ok()
         .flatten()
-        .unwrap_or_default()
+        .unwrap_or_default();
+    register_persisted_repos(&repos);
+    repos
 }
 
 #[tauri::command]
 pub(crate) fn save_repos(repos: Vec<Repo>) {
     if let Ok(metadata_dir) = global_metadata_dir() {
         let repos_path = metadata_dir.join("repos.json");
-        let _ = write_json_file(&repos_path, &repos);
+        let sanitized = sanitize_repos_for_persistence(repos);
+        let _ = write_json_file(&repos_path, &sanitized);
     }
 }
 
 #[tauri::command]
 pub(crate) fn load_workspace_metadata(repo_path: String) -> Option<RepoMetadata> {
     let normalized_path = normalize_non_empty_path(&repo_path)?;
+    let normalized_path = authorize_workspace_root(&normalized_path).ok()?;
     let metadata_path = normalized_path.join(".tabst").join("workspace.json");
 
     read_json_file::<RepoMetadata>(&metadata_path)
@@ -198,6 +205,10 @@ pub(crate) fn load_workspace_metadata(repo_path: String) -> Option<RepoMetadata>
 #[tauri::command]
 pub(crate) fn save_workspace_metadata(repo_path: String, metadata: RepoMetadata) {
     if let Some(normalized_path) = normalize_non_empty_path(&repo_path) {
+        let normalized_path = match authorize_workspace_root(&normalized_path) {
+            Ok(value) => value,
+            Err(_) => return,
+        };
         let workspace_dir = normalized_path.join(".tabst");
         let metadata_path = workspace_dir.join("workspace.json");
         let _ = write_json_file(&metadata_path, &metadata);
@@ -220,12 +231,25 @@ pub(crate) fn delete_file(
         }
     };
 
+    let (normalized_file_path, _) = match authorize_existing_workspace_path(&normalized_file_path) {
+        Ok(value) => value,
+        Err(error) => {
+            return BasicResult {
+                success: false,
+                error: Some(error),
+            };
+        }
+    };
+
     if behavior == "system-trash" {
         return match trash::delete(&normalized_file_path) {
-            Ok(()) => BasicResult {
-                success: true,
-                error: None,
-            },
+            Ok(()) => {
+                let _ = unregister_allowed_path(&normalized_file_path);
+                BasicResult {
+                    success: true,
+                    error: None,
+                }
+            }
             Err(error) => BasicResult {
                 success: false,
                 error: Some(to_error(error)),
@@ -244,6 +268,22 @@ pub(crate) fn delete_file(
                     };
                 }
             };
+        let normalized_repo_path = match authorize_workspace_root(&normalized_repo_path) {
+            Ok(value) => value,
+            Err(error) => {
+                return BasicResult {
+                    success: false,
+                    error: Some(error),
+                };
+            }
+        };
+
+        if !path_is_within_root(&normalized_repo_path, &normalized_file_path) {
+            return BasicResult {
+                success: false,
+                error: Some("path-outside-workspace".to_string()),
+            };
+        }
 
         let metadata_dir = match global_metadata_dir() {
             Ok(value) => value,
@@ -277,10 +317,13 @@ pub(crate) fn delete_file(
         let target_path = trash_dir.join(format!("{}_{}", now_ms(), file_name));
 
         return match rename_path(&normalized_file_path, &target_path) {
-            Ok(()) => BasicResult {
-                success: true,
-                error: None,
-            },
+            Ok(()) => {
+                let _ = unregister_allowed_path(&normalized_file_path);
+                BasicResult {
+                    success: true,
+                    error: None,
+                }
+            }
             Err(error) => BasicResult {
                 success: false,
                 error: Some(error),
@@ -306,6 +349,15 @@ pub(crate) fn start_repo_watch(
             return BasicResult {
                 success: false,
                 error: Some("invalid-repo-path".to_string()),
+            };
+        }
+    };
+    let normalized_repo_path = match authorize_workspace_root(&normalized_repo_path) {
+        Ok(value) => value,
+        Err(error) => {
+            return BasicResult {
+                success: false,
+                error: Some(error),
             };
         }
     };

--- a/src-tauri/src/support.rs
+++ b/src-tauri/src/support.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
@@ -184,18 +185,15 @@ pub(crate) fn replace_registered_exact_file(
     old_path: &Path,
     new_path: &Path,
 ) -> Result<(), String> {
-    let old_canonical = canonicalize_existing_path(old_path)?;
-    let new_canonical = canonicalize_existing_path(new_path)?;
-
     let mut guard = allowed_path_registry()
         .lock()
         .map_err(|_| "path-access-lock-failed".to_string())?;
     if let Some(index) = guard
         .exact_files
         .iter()
-        .position(|existing| existing == &old_canonical)
+        .position(|existing| existing.as_path() == old_path)
     {
-        guard.exact_files[index] = new_canonical;
+        guard.exact_files[index] = new_path.to_path_buf();
     }
     Ok(())
 }
@@ -328,14 +326,50 @@ pub(crate) fn validate_repo_relative_path(path: &str) -> Result<String, String> 
     Ok(value)
 }
 
-pub(crate) fn sanitize_repos_for_persistence(repos: Vec<Repo>) -> Vec<Repo> {
+pub(crate) fn normalize_loaded_repos(repos: Vec<Repo>) -> Vec<Repo> {
     repos
         .into_iter()
+        .map(|repo| {
+            let canonical_path = normalize_non_empty_path(&repo.path)
+                .and_then(|path| canonicalize_existing_path(&path).ok())
+                .filter(|path| path.is_dir());
+
+            match canonical_path {
+                Some(path) => Repo {
+                    path: path.to_string_lossy().to_string(),
+                    ..repo
+                },
+                None => repo,
+            }
+        })
+        .collect()
+}
+
+pub(crate) fn prepare_repos_for_persistence(
+    existing_repos: &[Repo],
+    incoming_repos: Vec<Repo>,
+) -> Vec<Repo> {
+    let existing_by_id = existing_repos
+        .iter()
+        .cloned()
+        .map(|repo| (repo.id.clone(), repo))
+        .collect::<HashMap<_, _>>();
+
+    incoming_repos
+        .into_iter()
         .filter_map(|repo| {
-            let path = normalize_non_empty_path(&repo.path)?;
-            let canonical_path = authorize_workspace_root(&path).ok()?;
-            Some(Repo {
-                path: canonical_path.to_string_lossy().to_string(),
+            let authorized_path = normalize_non_empty_path(&repo.path)
+                .and_then(|path| authorize_workspace_root(&path).ok());
+
+            if let Some(path) = authorized_path {
+                return Some(Repo {
+                    path: path.to_string_lossy().to_string(),
+                    ..repo
+                });
+            }
+
+            existing_by_id.get(&repo.id).map(|existing| Repo {
+                path: existing.path.clone(),
                 ..repo
             })
         })

--- a/src-tauri/src/support.rs
+++ b/src-tauri/src/support.rs
@@ -218,11 +218,27 @@ pub(crate) fn authorize_existing_workspace_path(
     path: &Path,
 ) -> Result<(PathBuf, WorkspacePathScope), String> {
     let canonical_path = canonicalize_existing_path(path)?;
-    let guard = allowed_path_registry()
-        .lock()
-        .map_err(|_| "path-access-lock-failed".to_string())?;
-    let scope = scope_for_canonical_path(&guard, &canonical_path)?
-        .ok_or_else(|| "path-outside-workspace".to_string())?;
+    let scope = {
+        let guard = allowed_path_registry()
+            .lock()
+            .map_err(|_| "path-access-lock-failed".to_string())?;
+        scope_for_canonical_path(&guard, &canonical_path)?
+    };
+
+    let scope = match scope {
+        Some(value) => value,
+        None => {
+            if !register_persisted_repo_scope_for_path(&canonical_path)? {
+                return Err("path-outside-workspace".to_string());
+            }
+
+            let guard = allowed_path_registry()
+                .lock()
+                .map_err(|_| "path-access-lock-failed".to_string())?;
+            scope_for_canonical_path(&guard, &canonical_path)?
+                .ok_or_else(|| "path-outside-workspace".to_string())?
+        }
+    };
 
     if !scope_allows_existing_path(&scope, &canonical_path) {
         return Err("path-outside-workspace".to_string());
@@ -269,6 +285,16 @@ pub(crate) fn authorize_workspace_root(path: &Path) -> Result<PathBuf, String> {
         .map_err(|_| "path-access-lock-failed".to_string())?;
     if guard.roots.iter().any(|root| root == &canonical_path) {
         return Ok(canonical_path);
+    }
+    drop(guard);
+
+    if register_persisted_repo_scope_for_path(&canonical_path)? {
+        let guard = allowed_path_registry()
+            .lock()
+            .map_err(|_| "path-access-lock-failed".to_string())?;
+        if guard.roots.iter().any(|root| root == &canonical_path) {
+            return Ok(canonical_path);
+        }
     }
 
     Err("path-outside-workspace".to_string())
@@ -384,6 +410,37 @@ pub(crate) fn register_persisted_repos(repos: &[Repo]) {
     }
 }
 
+fn register_persisted_repo_scope_for_path(canonical_path: &Path) -> Result<bool, String> {
+    let metadata_dir = match global_metadata_dir() {
+        Ok(value) => value,
+        Err(_) => return Ok(false),
+    };
+    let repos_path = metadata_dir.join("repos.json");
+    let repos = read_json_file::<Vec<Repo>>(&repos_path)
+        .ok()
+        .flatten()
+        .unwrap_or_default();
+
+    for repo in repos {
+        let Some(path) = normalize_non_empty_path(&repo.path) else {
+            continue;
+        };
+        let Ok(canonical_repo_path) = canonicalize_existing_path(&path) else {
+            continue;
+        };
+        if !canonical_repo_path.is_dir() {
+            continue;
+        }
+        if canonical_path == canonical_repo_path || canonical_path.starts_with(&canonical_repo_path)
+        {
+            register_allowed_root(&canonical_repo_path)?;
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
 pub(crate) fn sanitize_name(name: &str) -> String {
     name.chars()
         .map(|ch| match ch {
@@ -469,7 +526,9 @@ pub(crate) fn global_metadata_dir() -> Result<PathBuf, String> {
     Ok(metadata_dir)
 }
 
-pub(crate) fn app_state_path(app: &tauri::AppHandle) -> Result<PathBuf, String> {
+pub(crate) fn app_state_path<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+) -> Result<PathBuf, String> {
     let app_data = app.path().app_data_dir().map_err(to_error)?;
     fs::create_dir_all(&app_data).map_err(to_error)?;
     Ok(app_data.join("app-state.json"))

--- a/src-tauri/src/support.rs
+++ b/src-tauri/src/support.rs
@@ -1,13 +1,28 @@
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use dirs::{document_dir, home_dir};
 use serde::{de::DeserializeOwned, Serialize};
 use tauri::Manager;
 
+use crate::Repo;
+
 pub(crate) const RELEASES_FEED_URL: &str =
     "https://github.com/LIUBINfighter/Tabst.app/releases.atom";
+
+#[derive(Debug, Clone)]
+pub(crate) enum WorkspacePathScope {
+    Root(PathBuf),
+    ExactFile(PathBuf),
+}
+
+#[derive(Debug, Default)]
+struct AllowedPathRegistry {
+    roots: Vec<PathBuf>,
+    exact_files: Vec<PathBuf>,
+}
 
 pub(crate) fn now_ms() -> u64 {
     SystemTime::now()
@@ -51,6 +66,288 @@ pub(crate) fn normalize_non_empty_path(path: &str) -> Option<PathBuf> {
         return None;
     }
     Some(PathBuf::from(trimmed))
+}
+
+fn allowed_path_registry() -> &'static Mutex<AllowedPathRegistry> {
+    static REGISTRY: OnceLock<Mutex<AllowedPathRegistry>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(AllowedPathRegistry::default()))
+}
+
+fn push_unique_path(paths: &mut Vec<PathBuf>, candidate: PathBuf) {
+    if paths.iter().any(|existing| existing == &candidate) {
+        return;
+    }
+    paths.push(candidate);
+}
+
+fn implicit_default_workspace_root() -> Result<PathBuf, String> {
+    let default_root = default_save_dir();
+    fs::create_dir_all(&default_root).map_err(to_error)?;
+    fs::canonicalize(default_root).map_err(to_error)
+}
+
+pub(crate) fn canonicalize_existing_path(path: &Path) -> Result<PathBuf, String> {
+    fs::canonicalize(path).map_err(to_error)
+}
+
+pub(crate) fn canonicalize_target_path(path: &Path) -> Result<PathBuf, String> {
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| "invalid-path".to_string())?
+        .to_os_string();
+    let parent = path.parent().ok_or_else(|| "invalid-path".to_string())?;
+    let canonical_parent = fs::canonicalize(parent).map_err(to_error)?;
+    Ok(canonical_parent.join(file_name))
+}
+
+fn longest_matching_root<'a>(roots: &'a [PathBuf], path: &Path) -> Option<&'a PathBuf> {
+    roots
+        .iter()
+        .filter(|root| path.starts_with(root))
+        .max_by_key(|root| root.components().count())
+}
+
+fn scope_for_canonical_path(
+    registry: &AllowedPathRegistry,
+    canonical_path: &Path,
+) -> Result<Option<WorkspacePathScope>, String> {
+    let default_root = implicit_default_workspace_root()?;
+    if canonical_path.starts_with(&default_root) {
+        return Ok(Some(WorkspacePathScope::Root(default_root)));
+    }
+
+    if let Some(root) = longest_matching_root(&registry.roots, canonical_path) {
+        return Ok(Some(WorkspacePathScope::Root(root.clone())));
+    }
+
+    if let Some(file) = registry
+        .exact_files
+        .iter()
+        .find(|file| file.as_path() == canonical_path)
+    {
+        return Ok(Some(WorkspacePathScope::ExactFile(file.clone())));
+    }
+
+    Ok(None)
+}
+
+fn scope_allows_existing_path(scope: &WorkspacePathScope, canonical_path: &Path) -> bool {
+    match scope {
+        WorkspacePathScope::Root(root) => canonical_path.starts_with(root),
+        WorkspacePathScope::ExactFile(file_path) => {
+            canonical_path == file_path
+                || file_path
+                    .parent()
+                    .map(|parent| canonical_path == parent)
+                    .unwrap_or(false)
+        }
+    }
+}
+
+pub(crate) fn scope_allows_target_path(scope: &WorkspacePathScope, canonical_path: &Path) -> bool {
+    match scope {
+        WorkspacePathScope::Root(root) => canonical_path.starts_with(root),
+        WorkspacePathScope::ExactFile(file_path) => file_path
+            .parent()
+            .map(|parent| canonical_path.parent() == Some(parent))
+            .unwrap_or(false),
+    }
+}
+
+pub(crate) fn register_allowed_root(path: &Path) -> Result<PathBuf, String> {
+    let canonical_path = canonicalize_existing_path(path)?;
+    if !canonical_path.is_dir() {
+        return Err("invalid-repo-path".to_string());
+    }
+
+    let mut guard = allowed_path_registry()
+        .lock()
+        .map_err(|_| "path-access-lock-failed".to_string())?;
+    push_unique_path(&mut guard.roots, canonical_path.clone());
+    Ok(canonical_path)
+}
+
+pub(crate) fn register_allowed_file(path: &Path) -> Result<PathBuf, String> {
+    let canonical_path = canonicalize_existing_path(path)?;
+    if !canonical_path.is_file() {
+        return Err("invalid-file-path".to_string());
+    }
+
+    let mut guard = allowed_path_registry()
+        .lock()
+        .map_err(|_| "path-access-lock-failed".to_string())?;
+    push_unique_path(&mut guard.exact_files, canonical_path.clone());
+    Ok(canonical_path)
+}
+
+pub(crate) fn replace_registered_exact_file(
+    old_path: &Path,
+    new_path: &Path,
+) -> Result<(), String> {
+    let old_canonical = canonicalize_existing_path(old_path)?;
+    let new_canonical = canonicalize_existing_path(new_path)?;
+
+    let mut guard = allowed_path_registry()
+        .lock()
+        .map_err(|_| "path-access-lock-failed".to_string())?;
+    if let Some(index) = guard
+        .exact_files
+        .iter()
+        .position(|existing| existing == &old_canonical)
+    {
+        guard.exact_files[index] = new_canonical;
+    }
+    Ok(())
+}
+
+pub(crate) fn unregister_allowed_path(path: &Path) -> Result<(), String> {
+    let canonical_path = match canonicalize_existing_path(path) {
+        Ok(value) => value,
+        Err(_) => return Ok(()),
+    };
+
+    let mut guard = allowed_path_registry()
+        .lock()
+        .map_err(|_| "path-access-lock-failed".to_string())?;
+    guard
+        .exact_files
+        .retain(|existing| existing != &canonical_path);
+    guard.roots.retain(|existing| existing != &canonical_path);
+    Ok(())
+}
+
+pub(crate) fn authorize_existing_workspace_path(
+    path: &Path,
+) -> Result<(PathBuf, WorkspacePathScope), String> {
+    let canonical_path = canonicalize_existing_path(path)?;
+    let guard = allowed_path_registry()
+        .lock()
+        .map_err(|_| "path-access-lock-failed".to_string())?;
+    let scope = scope_for_canonical_path(&guard, &canonical_path)?
+        .ok_or_else(|| "path-outside-workspace".to_string())?;
+
+    if !scope_allows_existing_path(&scope, &canonical_path) {
+        return Err("path-outside-workspace".to_string());
+    }
+
+    Ok((canonical_path, scope))
+}
+
+pub(crate) fn authorize_existing_path_in_scope(
+    scope: &WorkspacePathScope,
+    path: &Path,
+) -> Result<PathBuf, String> {
+    let canonical_path = canonicalize_existing_path(path)?;
+    if scope_allows_existing_path(scope, &canonical_path) {
+        return Ok(canonical_path);
+    }
+    Err("path-outside-workspace".to_string())
+}
+
+pub(crate) fn authorize_target_path_in_scope(
+    scope: &WorkspacePathScope,
+    path: &Path,
+) -> Result<PathBuf, String> {
+    let canonical_path = canonicalize_target_path(path)?;
+    if scope_allows_target_path(scope, &canonical_path) {
+        return Ok(canonical_path);
+    }
+    Err("path-outside-workspace".to_string())
+}
+
+pub(crate) fn authorize_workspace_root(path: &Path) -> Result<PathBuf, String> {
+    let canonical_path = canonicalize_existing_path(path)?;
+    if !canonical_path.is_dir() {
+        return Err("invalid-repo-path".to_string());
+    }
+
+    let default_root = implicit_default_workspace_root()?;
+    if canonical_path.starts_with(&default_root) {
+        return Ok(canonical_path);
+    }
+
+    let guard = allowed_path_registry()
+        .lock()
+        .map_err(|_| "path-access-lock-failed".to_string())?;
+    if guard.roots.iter().any(|root| root == &canonical_path) {
+        return Ok(canonical_path);
+    }
+
+    Err("path-outside-workspace".to_string())
+}
+
+pub(crate) fn path_is_within_root(root: &Path, path: &Path) -> bool {
+    path.starts_with(root)
+}
+
+pub(crate) fn validate_child_name(name: &str) -> Result<String, String> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return Err("invalid-name".to_string());
+    }
+
+    let path = Path::new(trimmed);
+    if path.is_absolute() {
+        return Err("invalid-name".to_string());
+    }
+
+    let mut components = path.components();
+    match (components.next(), components.next()) {
+        (Some(Component::Normal(_)), None) => Ok(trimmed.to_string()),
+        _ => Err("invalid-name".to_string()),
+    }
+}
+
+pub(crate) fn validate_repo_relative_path(path: &str) -> Result<String, String> {
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        return Err("invalid-file-path".to_string());
+    }
+
+    let candidate = Path::new(trimmed);
+    if candidate.is_absolute() {
+        return Err("invalid-file-path".to_string());
+    }
+
+    let mut normalized = PathBuf::new();
+    for component in candidate.components() {
+        match component {
+            Component::CurDir => continue,
+            Component::Normal(part) => normalized.push(part),
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err("invalid-file-path".to_string());
+            }
+        }
+    }
+
+    let value = normalized.to_string_lossy().replace('\\', "/");
+    if value.is_empty() {
+        return Err("invalid-file-path".to_string());
+    }
+
+    Ok(value)
+}
+
+pub(crate) fn sanitize_repos_for_persistence(repos: Vec<Repo>) -> Vec<Repo> {
+    repos
+        .into_iter()
+        .filter_map(|repo| {
+            let path = normalize_non_empty_path(&repo.path)?;
+            let canonical_path = authorize_workspace_root(&path).ok()?;
+            Some(Repo {
+                path: canonical_path.to_string_lossy().to_string(),
+                ..repo
+            })
+        })
+        .collect()
+}
+
+pub(crate) fn register_persisted_repos(repos: &[Repo]) {
+    for repo in repos {
+        if let Some(path) = normalize_non_empty_path(&repo.path) {
+            let _ = register_allowed_root(&path);
+        }
+    }
 }
 
 pub(crate) fn sanitize_name(name: &str) -> String {

--- a/src/renderer/components/Editor.tsx
+++ b/src/renderer/components/Editor.tsx
@@ -27,6 +27,11 @@ import {
 	type GlobalCommandId,
 	type InlineCommandId,
 } from "../lib/command-registry";
+import {
+	createEditorAutosaveRequest,
+	type EditorAutosaveRequest,
+	planEditorAutosaveTransition,
+} from "../lib/editor-autosave";
 import { runUiCommand } from "../lib/ui-command-registry";
 import {
 	isWebsiteMobileLayout,
@@ -75,6 +80,8 @@ export function Editor({
 	const playbackHighlightRafRef = useRef<number | null>(null);
 	const lastContentRef = useRef<string>("");
 	const focusCleanupRef = useRef<(() => void) | null>(null);
+	const activeFileRef = useRef<FileItem | null>(null);
+	const pendingAutosaveRef = useRef<EditorAutosaveRequest | null>(null);
 	const [previewApi, setPreviewApi] = useState<TracksPanelProps["api"]>(null);
 	const [inlineCommandOpen, setInlineCommandOpen] = useState(false);
 	const [inlineCommandTop, setInlineCommandTop] = useState(8);
@@ -92,6 +99,7 @@ export function Editor({
 		s.files.find((f) => f.id === s.activeFileId),
 	);
 	const activeFile = sandboxFile ?? activeFileFromStore;
+	activeFileRef.current = activeFile ?? null;
 	const setWorkspaceMode = useAppStore((s) => s.setWorkspaceMode);
 	const workspaceMode = useAppStore((s) => s.workspaceMode);
 	const isTracksPanelOpen = useAppStore((s) => s.isTracksPanelOpen);
@@ -143,14 +151,22 @@ export function Editor({
 		cleanupLSP,
 	} = useEditorLSP();
 
+	const commitAutosave = useCallback(async (request: EditorAutosaveRequest) => {
+		try {
+			await window.desktopAPI.saveFile(request.filePath, request.content);
+		} catch (err) {
+			console.error("Failed to save file:", err);
+		}
+	}, []);
+
 	// Create update listener
 	const createUpdateListener = useCallback(() => {
 		return EditorView.updateListener.of((update: ViewUpdate) => {
 			if (update.docChanged && !isUpdatingRef.current) {
 				const newContent = update.state.doc.toString();
 				lastContentRef.current = newContent;
-				const currentActiveId =
-					sandboxFile?.id ?? useAppStore.getState().activeFileId;
+				const activeFileAtEdit = sandboxFile ?? activeFileRef.current;
+				const currentActiveId = activeFileAtEdit?.id ?? null;
 
 				if (sandboxFile) {
 					onSandboxContentChange?.(newContent);
@@ -158,27 +174,50 @@ export function Editor({
 					useAppStore.getState().updateFileContent(currentActiveId, newContent);
 				}
 
-				if (saveTimerRef.current) {
+				const nextAutosave = createEditorAutosaveRequest({
+					activeFile: activeFileAtEdit
+						? {
+								id: activeFileAtEdit.id,
+								path: activeFileAtEdit.path,
+							}
+						: null,
+					newContent,
+					sandboxFile: sandboxFile
+						? {
+								id: sandboxFile.id,
+								path: sandboxFile.path,
+							}
+						: null,
+					sandboxMode,
+				});
+				const transition = planEditorAutosaveTransition(
+					pendingAutosaveRef.current,
+					nextAutosave,
+				);
+
+				if (transition.clearCurrentTimer && saveTimerRef.current) {
 					clearTimeout(saveTimerRef.current);
+					saveTimerRef.current = null;
 				}
 
-				saveTimerRef.current = window.setTimeout(async () => {
-					if (!sandboxMode && !sandboxFile) {
-						const state = useAppStore.getState();
-						const file = state.files.find((f) => f.id === state.activeFileId);
-						if (file) {
-							try {
-								await window.desktopAPI.saveFile(file.path, newContent);
-							} catch (err) {
-								console.error("Failed to save file:", err);
-							}
-						}
+				if (transition.flushImmediately) {
+					void commitAutosave(transition.flushImmediately);
+				}
+
+				pendingAutosaveRef.current = transition.nextPending;
+				if (!transition.nextPending) return;
+
+				const scheduledRequest = transition.nextPending;
+				saveTimerRef.current = window.setTimeout(() => {
+					void commitAutosave(scheduledRequest);
+					if (pendingAutosaveRef.current?.fileId === scheduledRequest.fileId) {
+						pendingAutosaveRef.current = null;
 					}
 					saveTimerRef.current = null;
 				}, 800);
 			}
 		});
-	}, [onSandboxContentChange, sandboxFile, sandboxMode]);
+	}, [commitAutosave, onSandboxContentChange, sandboxFile, sandboxMode]);
 
 	// Main effect: Create editor or update it when file changes
 	useEffect(() => {
@@ -592,6 +631,7 @@ export function Editor({
 				clearTimeout(saveTimerRef.current);
 				saveTimerRef.current = null;
 			}
+			pendingAutosaveRef.current = null;
 		};
 	}, [cleanupLSP]);
 
@@ -612,6 +652,7 @@ export function Editor({
 			clearTimeout(saveTimerRef.current);
 			saveTimerRef.current = null;
 		}
+		pendingAutosaveRef.current = null;
 	}, [cleanupLSP, enjoyMode]);
 
 	// Cleanup editor when no active file - use useLayoutEffect to ensure cleanup before render

--- a/src/renderer/components/Editor.tsx
+++ b/src/renderer/components/Editor.tsx
@@ -31,6 +31,7 @@ import {
 	createEditorAutosaveRequest,
 	type EditorAutosaveRequest,
 	planEditorAutosaveTransition,
+	rebindEditorAutosaveRequest,
 } from "../lib/editor-autosave";
 import { runUiCommand } from "../lib/ui-command-registry";
 import {
@@ -152,11 +153,48 @@ export function Editor({
 	} = useEditorLSP();
 
 	const commitAutosave = useCallback(async (request: EditorAutosaveRequest) => {
+		const latestFile = useAppStore
+			.getState()
+			.files.find((file) => file.id === request.fileId);
+		const nextRequest = rebindEditorAutosaveRequest(
+			request,
+			latestFile
+				? {
+						id: latestFile.id,
+						path: latestFile.path,
+					}
+				: null,
+		);
+		if (!nextRequest) return;
+
 		try {
-			await window.desktopAPI.saveFile(request.filePath, request.content);
+			await window.desktopAPI.saveFile(
+				nextRequest.filePath,
+				nextRequest.content,
+			);
 		} catch (err) {
 			console.error("Failed to save file:", err);
 		}
+	}, []);
+
+	useEffect(() => {
+		return useAppStore.subscribe((state, previousState) => {
+			const pendingRequest = pendingAutosaveRef.current;
+			if (!pendingRequest) return;
+
+			const nextFile = state.files.find(
+				(file) => file.id === pendingRequest.fileId,
+			);
+			const previousFile = previousState.files.find(
+				(file) => file.id === pendingRequest.fileId,
+			);
+			if (!nextFile || nextFile.path === previousFile?.path) return;
+
+			pendingAutosaveRef.current = rebindEditorAutosaveRequest(pendingRequest, {
+				id: nextFile.id,
+				path: nextFile.path,
+			});
+		});
 	}, []);
 
 	// Create update listener
@@ -209,7 +247,11 @@ export function Editor({
 
 				const scheduledRequest = transition.nextPending;
 				saveTimerRef.current = window.setTimeout(() => {
-					void commitAutosave(scheduledRequest);
+					const latestPending =
+						pendingAutosaveRef.current?.fileId === scheduledRequest.fileId
+							? pendingAutosaveRef.current
+							: scheduledRequest;
+					void commitAutosave(latestPending);
 					if (pendingAutosaveRef.current?.fileId === scheduledRequest.fileId) {
 						pendingAutosaveRef.current = null;
 					}

--- a/src/renderer/lib/desktop-api.test.ts
+++ b/src/renderer/lib/desktop-api.test.ts
@@ -1,13 +1,68 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createWebDesktopAPI, shouldUseTauriDesktopApi } from "./desktop-api";
 
+class MemoryStorage {
+	private values = new Map<string, string>();
+
+	getItem(key: string) {
+		return this.values.has(key) ? (this.values.get(key) ?? null) : null;
+	}
+
+	setItem(key: string, value: string) {
+		this.values.set(key, value);
+	}
+
+	removeItem(key: string) {
+		this.values.delete(key);
+	}
+
+	clear() {
+		this.values.clear();
+	}
+}
+
+type MockInputElement = {
+	type: string;
+	accept?: string;
+	multiple?: boolean;
+	files: File[] | null;
+	onchange: null | (() => void);
+	click: () => void;
+	webkitdirectory?: boolean;
+};
+
+let nextPickedFiles: File[] = [];
+
 beforeEach(() => {
+	const localStorage = new MemoryStorage();
+
 	Object.defineProperty(globalThis, "window", {
 		value: {
 			open: vi.fn(),
+			localStorage,
 		},
 		configurable: true,
 	});
+
+	Object.defineProperty(globalThis, "document", {
+		value: {
+			createElement: vi.fn((): MockInputElement => {
+				const input: MockInputElement = {
+					type: "file",
+					files: null,
+					onchange: null,
+					click: () => {
+						input.files = nextPickedFiles;
+						input.onchange?.();
+					},
+				};
+				return input;
+			}),
+		},
+		configurable: true,
+	});
+
+	nextPickedFiles = [];
 });
 
 describe("tauri runtime detection", () => {
@@ -72,6 +127,47 @@ describe("tauri runtime detection", () => {
 			"https://example.com/docs",
 			"_blank",
 			"noopener,noreferrer",
+		);
+	});
+
+	it("preserves binary gp bytes when importing through openFile", async () => {
+		const api = createWebDesktopAPI();
+		const originalBytes = Uint8Array.from([0, 255, 254, 65, 0, 66, 67]);
+		nextPickedFiles = [
+			new File([originalBytes], "song.gp5", {
+				type: "application/octet-stream",
+			}),
+		];
+
+		const result = await api.openFile([".gp5"]);
+		expect(result).not.toBeNull();
+
+		const readResult = await api.readFileBytes(result?.path ?? "");
+		expect(Array.from(readResult.data ?? [])).toEqual(
+			Array.from(originalBytes),
+		);
+	});
+
+	it("preserves binary gp bytes when importing a directory in web runtime", async () => {
+		const api = createWebDesktopAPI();
+		const originalBytes = Uint8Array.from([71, 80, 53, 0, 255, 10, 13]);
+		const file = new File([originalBytes], "riff.gp5", {
+			type: "application/octet-stream",
+		});
+		Object.defineProperty(file, "webkitRelativePath", {
+			value: "session/riff.gp5",
+			configurable: true,
+		});
+		nextPickedFiles = [file];
+
+		const repoPath = await api.selectFolder();
+		expect(repoPath).toBeTruthy();
+
+		const tree = await api.scanDirectory(repoPath ?? "");
+		const importedPath = tree?.nodes[0]?.path ?? "";
+		const readResult = await api.readFileBytes(importedPath);
+		expect(Array.from(readResult.data ?? [])).toEqual(
+			Array.from(originalBytes),
 		);
 	});
 });

--- a/src/renderer/lib/desktop-api.ts
+++ b/src/renderer/lib/desktop-api.ts
@@ -6,9 +6,11 @@ import type {
 } from "../types/desktop";
 import type { GitChangeGroup } from "../types/git";
 import type { FileNode, Repo, RepoMetadata } from "../types/repo";
+import { isGpFilePath } from "./gp-import";
 import { createTauriDesktopAPI } from "./tauri-desktop-api";
 
 interface BrowserStoredFile {
+	binaryData?: number[];
 	path: string;
 	name: string;
 	content: string;
@@ -157,6 +159,25 @@ function fileNameFromPath(path: string): string {
 	return segments[segments.length - 1] || path;
 }
 
+async function createBrowserStoredFile(
+	file: File,
+	path: string,
+	repoPath: string,
+): Promise<BrowserStoredFile> {
+	const isBinaryGpFile = isGpFilePath(file.name);
+
+	return {
+		path,
+		name: file.name,
+		content: isBinaryGpFile ? "" : await file.text(),
+		binaryData: isBinaryGpFile
+			? Array.from(new Uint8Array(await file.arrayBuffer()))
+			: undefined,
+		repoPath,
+		updatedAt: Date.now(),
+	};
+}
+
 export function createWebDesktopAPI(): DesktopAPI {
 	const api: DesktopAPI = {
 		openFile: async (extensions: string[]): Promise<FileResult | null> => {
@@ -165,19 +186,16 @@ export function createWebDesktopAPI(): DesktopAPI {
 			if (!files.length) return null;
 
 			const pickedFile = files[0];
-			const content = await pickedFile.text();
 			const repoPath = "web://scratch";
 			const path = makeFilePath(
 				repoPath,
 				`${crypto.randomUUID()}-${pickedFile.name}`,
 			);
-			const nextFile: BrowserStoredFile = {
+			const nextFile = await createBrowserStoredFile(
+				pickedFile,
 				path,
-				name: pickedFile.name,
-				content,
 				repoPath,
-				updatedAt: Date.now(),
-			};
+			);
 			const allFiles = getAllFiles();
 			allFiles[path] = nextFile;
 			saveAllFiles(allFiles);
@@ -185,7 +203,7 @@ export function createWebDesktopAPI(): DesktopAPI {
 			return {
 				path,
 				name: pickedFile.name,
-				content,
+				content: nextFile.content,
 			};
 		},
 
@@ -249,6 +267,7 @@ export function createWebDesktopAPI(): DesktopAPI {
 				path: filePath,
 				name: existing?.name ?? fileNameFromPath(filePath),
 				content,
+				binaryData: undefined,
 				repoPath: existing?.repoPath ?? "web://scratch",
 				updatedAt: Date.now(),
 			};
@@ -371,16 +390,14 @@ export function createWebDesktopAPI(): DesktopAPI {
 					.slice(1)
 					.join("/");
 				if (!relativePath) continue;
-				const content = await file.text();
 				const fullPath = makeFilePath(repoPath, relativePath);
-				const allFiles = getAllFiles();
-				allFiles[fullPath] = {
-					path: fullPath,
-					name: file.name,
-					content,
+				const nextFile = await createBrowserStoredFile(
+					file,
+					fullPath,
 					repoPath,
-					updatedAt: Date.now(),
-				};
+				);
+				const allFiles = getAllFiles();
+				allFiles[fullPath] = nextFile;
 				saveAllFiles(allFiles);
 			}
 
@@ -402,8 +419,10 @@ export function createWebDesktopAPI(): DesktopAPI {
 			if (!file) {
 				return { error: "File not found" };
 			}
-			const data = new TextEncoder().encode(file.content);
-			return { data };
+			if (file.binaryData) {
+				return { data: Uint8Array.from(file.binaryData) };
+			}
+			return { data: new TextEncoder().encode(file.content) };
 		},
 
 		scanDirectory: async (

--- a/src/renderer/lib/editor-autosave.test.ts
+++ b/src/renderer/lib/editor-autosave.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+	createEditorAutosaveRequest,
+	planEditorAutosaveTransition,
+} from "./editor-autosave";
+
+describe("editor autosave", () => {
+	it("captures the edited file path at change time", () => {
+		const request = createEditorAutosaveRequest({
+			activeFile: {
+				id: "file-a",
+				path: "/workspace/file-a.atex",
+			},
+			newContent: "edited-a",
+			sandboxFile: null,
+			sandboxMode: false,
+		});
+
+		expect(request).toEqual({
+			fileId: "file-a",
+			filePath: "/workspace/file-a.atex",
+			content: "edited-a",
+		});
+	});
+
+	it("flushes the previous pending save before scheduling a different file", () => {
+		const pendingForA = createEditorAutosaveRequest({
+			activeFile: {
+				id: "file-a",
+				path: "/workspace/file-a.atex",
+			},
+			newContent: "edited-a",
+			sandboxFile: null,
+			sandboxMode: false,
+		});
+		const pendingForB = createEditorAutosaveRequest({
+			activeFile: {
+				id: "file-b",
+				path: "/workspace/file-b.atex",
+			},
+			newContent: "edited-b",
+			sandboxFile: null,
+			sandboxMode: false,
+		});
+
+		const transition = planEditorAutosaveTransition(pendingForA, pendingForB);
+
+		expect(transition).toEqual({
+			clearCurrentTimer: true,
+			flushImmediately: pendingForA,
+			nextPending: pendingForB,
+		});
+	});
+
+	it("does not create a filesystem autosave request for sandbox edits", () => {
+		const request = createEditorAutosaveRequest({
+			activeFile: {
+				id: "sandbox-file",
+				path: "/workspace/file-a.atex",
+			},
+			newContent: "edited",
+			sandboxFile: {
+				id: "sandbox-file",
+				path: "/workspace/file-a.atex",
+			},
+			sandboxMode: true,
+		});
+
+		expect(request).toBeNull();
+	});
+});

--- a/src/renderer/lib/editor-autosave.test.ts
+++ b/src/renderer/lib/editor-autosave.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
 	createEditorAutosaveRequest,
 	planEditorAutosaveTransition,
+	rebindEditorAutosaveRequest,
 } from "./editor-autosave";
 
 describe("editor autosave", () => {
@@ -67,5 +68,28 @@ describe("editor autosave", () => {
 		});
 
 		expect(request).toBeNull();
+	});
+
+	it("rebinds a pending save to the latest path after a rename", () => {
+		const request = createEditorAutosaveRequest({
+			activeFile: {
+				id: "file-a",
+				path: "/workspace/file-a.atex",
+			},
+			newContent: "edited-a",
+			sandboxFile: null,
+			sandboxMode: false,
+		});
+
+		const rebound = rebindEditorAutosaveRequest(request, {
+			id: "file-a",
+			path: "/workspace/renamed.atex",
+		});
+
+		expect(rebound).toEqual({
+			fileId: "file-a",
+			filePath: "/workspace/renamed.atex",
+			content: "edited-a",
+		});
 	});
 });

--- a/src/renderer/lib/editor-autosave.ts
+++ b/src/renderer/lib/editor-autosave.ts
@@ -1,0 +1,72 @@
+export interface EditorAutosaveFileRef {
+	id: string;
+	path: string;
+}
+
+export interface EditorAutosaveRequest {
+	fileId: string;
+	filePath: string;
+	content: string;
+}
+
+export interface EditorAutosaveTransition {
+	clearCurrentTimer: boolean;
+	flushImmediately: EditorAutosaveRequest | null;
+	nextPending: EditorAutosaveRequest | null;
+}
+
+interface CreateEditorAutosaveRequestInput {
+	activeFile: EditorAutosaveFileRef | null;
+	newContent: string;
+	sandboxFile: EditorAutosaveFileRef | null;
+	sandboxMode: boolean;
+}
+
+export function createEditorAutosaveRequest(
+	input: CreateEditorAutosaveRequestInput,
+): EditorAutosaveRequest | null {
+	if (input.sandboxMode || input.sandboxFile || !input.activeFile) {
+		return null;
+	}
+
+	return {
+		fileId: input.activeFile.id,
+		filePath: input.activeFile.path,
+		content: input.newContent,
+	};
+}
+
+export function planEditorAutosaveTransition(
+	currentPending: EditorAutosaveRequest | null,
+	nextPending: EditorAutosaveRequest | null,
+): EditorAutosaveTransition {
+	if (!nextPending) {
+		return {
+			clearCurrentTimer: false,
+			flushImmediately: null,
+			nextPending: null,
+		};
+	}
+
+	if (!currentPending) {
+		return {
+			clearCurrentTimer: false,
+			flushImmediately: null,
+			nextPending,
+		};
+	}
+
+	if (currentPending.fileId === nextPending.fileId) {
+		return {
+			clearCurrentTimer: true,
+			flushImmediately: null,
+			nextPending,
+		};
+	}
+
+	return {
+		clearCurrentTimer: true,
+		flushImmediately: currentPending,
+		nextPending,
+	};
+}

--- a/src/renderer/lib/editor-autosave.ts
+++ b/src/renderer/lib/editor-autosave.ts
@@ -36,6 +36,24 @@ export function createEditorAutosaveRequest(
 	};
 }
 
+export function rebindEditorAutosaveRequest(
+	request: EditorAutosaveRequest | null,
+	file: EditorAutosaveFileRef | null,
+): EditorAutosaveRequest | null {
+	if (!request || !file || file.id !== request.fileId) {
+		return request;
+	}
+
+	if (file.path === request.filePath) {
+		return request;
+	}
+
+	return {
+		...request,
+		filePath: file.path,
+	};
+}
+
 export function planEditorAutosaveTransition(
 	currentPending: EditorAutosaveRequest | null,
 	nextPending: EditorAutosaveRequest | null,


### PR DESCRIPTION
## Issues
Fixes #130
Fixes #131
Fixes #132

## Proposed changes
- Hardens Tauri path scoping for repo roots and exact-file scopes, including canonical repo paths, exact-file registration updates after rename/move, and persisted repo re-authorization after reconnect.
- Restores standalone file session recovery by re-registering exact-file access before loading app state.
- Fixes editor autosave to snapshot file identity at edit time, flush cross-file pending saves safely, and rebind pending saves to the latest path after rename/move.
- Preserves binary GP imports in the web desktop adapter for both single-file import and folder import.
- Adds regression coverage in Vitest and Rust for autosave rebinding, GP byte preservation, standalone app-state restore, offline repo reconnect, canonical repo loading, and exact-file rename handling.
- Validation: 
> tabst@0.6.8 check /Users/jaybridge/Workspace/Tabst.app
> pnpm format:check && pnpm lint && pnpm type-check


> tabst@0.6.8 format:check /Users/jaybridge/Workspace/Tabst.app
> biome ci --formatter-enabled=true --linter-enabled=false --assist-enabled=true --enforce-assist=true --error-on-warnings src

> tabst@0.6.8 lint /Users/jaybridge/Workspace/Tabst.app
> biome ci --linter-enabled=true --formatter-enabled=false --error-on-warnings src

> tabst@0.6.8 type-check /Users/jaybridge/Workspace/Tabst.app
> tsc --noEmit, 
 RUN  v4.0.18 /Users/jaybridge/Workspace/Tabst.app

 ✓ src/renderer/lib/numbered-notation-guard.test.ts (6 tests) 2ms
 ✓ src/renderer/lib/perf-thresholds.test.ts (5 tests) 3ms
 ✓ src/renderer/lib/codemirror-highlight-regression.test.ts (1 test) 3ms
 ✓ src/renderer/lib/playback-range-cache.test.ts (3 tests) 3ms
 ✓ src/renderer/lib/tauri-invoke-args.test.ts (4 tests) 4ms
 ✓ src/renderer/lib/global-settings.test.ts (3 tests) 2ms
 ✓ src/renderer/lib/atdoc.test.ts (4 tests) 3ms
 ✓ src/renderer/lib/desktop-api.test.ts (7 tests) 11ms
 ✓ src/renderer/lib/workspace-metadata-store.test.ts (1 test) 2ms
 ✓ src/renderer/lib/player-audio-recovery.test.ts (7 tests) 158ms
 ✓ src/renderer/lib/editor-autosave.test.ts (4 tests) 2ms
 ✓ src/renderer/lib/website-layout.test.ts (7 tests) 1ms
 ✓ src/renderer/lib/playback-frame-gate.test.ts (3 tests) 2ms
 ✓ src/renderer/lib/player-audio.test.ts (4 tests) 3ms
 ✓ src/renderer/lib/repo-links.test.ts (7 tests) 1ms
 ✓ src/renderer/lib/theme-system/editor-theme-adapter.test.ts (4 tests) 2ms
 ✓ src/renderer/lib/shortcut-manager.test.ts (1 test) 3ms
 ✓ src/renderer/lib/print-fonts.test.ts (3 tests) 1ms
 ✓ src/renderer/lib/print-window.test.ts (3 tests) 1ms
 ✓ src/renderer/lib/app-zoom.test.ts (2 tests) 1ms

 Test Files  20 passed (20)
      Tests  79 passed (79)
   Start at  20:41:10
   Duration  497ms (transform 574ms, setup 0ms, import 912ms, tests 209ms, environment 2ms), and 
running 13 tests
test tests::asset_path_aliases_include_root_docs_files ... ok
test tests::notify_kind_mapping_matches_legacy_watch_contract ... ok
test tests::repo_metadata_roundtrip_preserves_workspace_session_fields ... ok
test tests::delete_file_repo_trash_rejects_paths_outside_the_repo_root ... ok
test tests::rename_file_rejects_names_that_escape_the_parent_directory ... ok
test tests::move_path_rejects_cross_workspace_moves ... ok
test tests::update_support_matrix_matches_tauri_release_policy ... ok
test tests::rename_file_keeps_exact_file_registration_in_sync ... ok
test tests::load_app_state_restores_standalone_files_from_previous_session ... ok
test tests::load_repos_returns_canonical_paths_for_accessible_entries ... ok
test tests::authorize_workspace_root_re_registers_persisted_repos_after_reconnect ... ok
test tests::save_repos_preserves_temporarily_unavailable_entries ... ok
Initialized empty Git repository in /private/var/folders/93/5ny43nm923ddw1v5tpt8fxc80000gn/T/tabst-tauri-parity-git-pathspec-scope-68466-1773924076548/.git/
test tests::stage_git_file_rejects_parent_directory_pathspecs ... ok

test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.03s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s. The skipped watcher case remains tracked separately in #134.

## Checklist
- [x] I consent that this change becomes part of Tabst under its current or any future open source license
- [x] Changes are implemented
- [x] New tests were added

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website