### PR TITLE
refactor(preview): reorganize imports and improve code formatting

### DIFF
--- a/src/renderer/components/Preview.tsx
+++ b/src/renderer/components/Preview.tsx
@@ -10,10 +10,6 @@ import {
 } from "react";
 import { useTranslation } from "react-i18next";
 import {
-	destroyPreviewApi,
-	usePrintPreviewApiLifecycle,
-} from "../hooks/usePreviewApiLifecycle";
-import {
 	getCountInVolume,
 	resolvePreviewPlayerState,
 } from "../hooks/preview-count-in";
@@ -21,6 +17,10 @@ import {
 	captureTrackConfigForRebuild,
 	shouldStartThemeRebuild,
 } from "../hooks/preview-session-controller";
+import {
+	destroyPreviewApi,
+	usePrintPreviewApiLifecycle,
+} from "../hooks/usePreviewApiLifecycle";
 import { usePreviewBarHighlight } from "../hooks/usePreviewBarHighlight";
 import { usePreviewErrorRecovery } from "../hooks/usePreviewErrorRecovery";
 import { usePreviewEventBindings } from "../hooks/usePreviewEventBindings";
@@ -1870,8 +1870,9 @@ export default function Preview({
 						void (async () => {
 							try {
 								// 保存当前的 tracks 配置
-								const trackConfigSnapshot =
-									captureTrackConfigForRebuild(apiRef.current);
+								const trackConfigSnapshot = captureTrackConfigForRebuild(
+									apiRef.current,
+								);
 								if (trackConfigSnapshot) {
 									trackConfigRef.current = trackConfigSnapshot;
 									// Saved tracks config before rebuild
@@ -1888,13 +1889,16 @@ export default function Preview({
 								const newColors = getAlphaTabColorsForTheme();
 
 								// 使用工具函数重新创建 API 配置
-								const newSettings = createPreviewSettings(urls as ResourceUrls, {
-									scale: getEffectivePreviewScale(zoomRef.current),
-									scrollElement:
-										(scrollHostRef.current as HTMLElement | null) ?? scrollEl,
-									enablePlayer: !editorHasFocusRef.current,
-									colors: newColors,
-								});
+								const newSettings = createPreviewSettings(
+									urls as ResourceUrls,
+									{
+										scale: getEffectivePreviewScale(zoomRef.current),
+										scrollElement:
+											(scrollHostRef.current as HTMLElement | null) ?? scrollEl,
+										enablePlayer: !editorHasFocusRef.current,
+										colors: newColors,
+									},
+								);
 
 								// 创建新的 API
 								apiRef.current = new alphaTab.AlphaTabApi(el, newSettings);
@@ -1910,10 +1914,10 @@ export default function Preview({
 									apiRef.current.playbackSpeed = playbackSpeedRef.current;
 									apiRef.current.masterVolume = masterVolumeRef.current;
 									apiRef.current.metronomeVolume = metronomeVolumeRef.current;
-										apiRef.current.countInVolume = getCountInVolume({
-											countInEnabled: countInEnabledRef.current,
-											metronomeVolume: metronomeVolumeRef.current,
-										});
+									apiRef.current.countInVolume = getCountInVolume({
+										countInEnabled: countInEnabledRef.current,
+										metronomeVolume: metronomeVolumeRef.current,
+									});
 								} catch {
 									// Failed to reapply speed/metronome after rebuild
 								}

--- a/src/renderer/hooks/preview-count-in.test.ts
+++ b/src/renderer/hooks/preview-count-in.test.ts
@@ -6,20 +6,24 @@ import {
 
 describe("getCountInVolume", () => {
 	it("disables count-in volume when count-in is turned off", () => {
-		expect(getCountInVolume({ countInEnabled: false, metronomeVolume: 0.6 })).toBe(
-			0,
-		);
+		expect(
+			getCountInVolume({ countInEnabled: false, metronomeVolume: 0.6 }),
+		).toBe(0);
 	});
 
 	it("reuses the metronome volume when count-in is enabled", () => {
-		expect(getCountInVolume({ countInEnabled: true, metronomeVolume: 0.35 })).toBe(
-			0.35,
-		);
+		expect(
+			getCountInVolume({ countInEnabled: true, metronomeVolume: 0.35 }),
+		).toBe(0.35);
 	});
 
 	it("clamps the derived count-in volume into alphaTab's expected range", () => {
-		expect(getCountInVolume({ countInEnabled: true, metronomeVolume: -1 })).toBe(0);
-		expect(getCountInVolume({ countInEnabled: true, metronomeVolume: 3 })).toBe(1);
+		expect(
+			getCountInVolume({ countInEnabled: true, metronomeVolume: -1 }),
+		).toBe(0);
+		expect(getCountInVolume({ countInEnabled: true, metronomeVolume: 3 })).toBe(
+			1,
+		);
 	});
 });
 

--- a/src/renderer/hooks/preview-session-controller.test.ts
+++ b/src/renderer/hooks/preview-session-controller.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
-	PREVIEW_THEME_REBUILD_COOLDOWN_MS,
 	captureTrackConfigForRebuild,
+	PREVIEW_THEME_REBUILD_COOLDOWN_MS,
 	shouldStartThemeRebuild,
 } from "./preview-session-controller";
 

--- a/src/renderer/lib/alphatab-font-warning-filter.ts
+++ b/src/renderer/lib/alphatab-font-warning-filter.ts
@@ -12,17 +12,19 @@ type SuppressOptions = {
 	message: string;
 };
 
-const FONT_WARNING_PATTERN = /^Could not load font '([^']+)' within \d+ seconds$/;
+const FONT_WARNING_PATTERN =
+	/^Could not load font '([^']+)' within \d+ seconds$/;
 
-export function parseAlphaTabFontWarningFamily(
-	message: string,
-): string | null {
+export function parseAlphaTabFontWarningFamily(message: string): string | null {
 	const match = FONT_WARNING_PATTERN.exec(message.trim());
 	return match?.[1] ?? null;
 }
 
 function defaultCheckFontAvailable(family: string): boolean {
-	if (typeof document === "undefined" || typeof document.fonts?.check !== "function") {
+	if (
+		typeof document === "undefined" ||
+		typeof document.fonts?.check !== "function"
+	) {
 		return false;
 	}
 


### PR DESCRIPTION
- Moved `destroyPreviewApi` and `usePrintPreviewApiLifecycle` imports to a more appropriate location.
- Enhanced readability by formatting function calls and object literals across the `Preview` component.
- Updated test cases for `getCountInVolume` to improve clarity and consistency in assertions.
- Minor adjustments in `alphatab-font-warning-filter` for better code structure.

## Issues
<!-- Strongly recommended: link a related issue here when available -->
Fixes some lint error

## Proposed changes

## Checklist
- [x] I consent that this change becomes part of Tabst under its current or any future open source license
- [x] Changes are implemented
- [ ] New tests were added <!-- Strongly recommended. If no tests were added, explain why. -->

## Further details
- [ ] This is a breaking change
- [ ] This change will require update of the documentation/website
