### PR TITLE
fix: remove browser headers and footers from print output

### DIFF
--- a/src/renderer/components/PrintPreview.tsx
+++ b/src/renderer/components/PrintPreview.tsx
@@ -706,6 +706,23 @@ export default function PrintPreview({
 								</div>
 							)}
 
+							{printStatus && (
+								<span
+									className="max-w-[20rem] truncate text-xs text-amber-700"
+									title={printStatus}
+								>
+									{printStatus}
+								</span>
+							)}
+							{fontError && (
+								<span
+									className="text-xs text-amber-600"
+									title={t("fontLoadFailed")}
+								>
+									⚠️ 字体
+								</span>
+							)}
+
 							<Button
 								size="sm"
 								className="px-2 print-btn h-8 text-xs"
@@ -715,22 +732,6 @@ export default function PrintPreview({
 							>
 								<Printer className="h-3 w-3 mr-1" /> {t("printExport")}
 							</Button>
-							{fontError && (
-								<span
-									className="text-xs text-amber-600"
-									title={t("fontLoadFailed")}
-								>
-									⚠️ 字体
-								</span>
-							)}
-							{printStatus && (
-								<span
-									className="max-w-[20rem] truncate text-xs text-amber-700"
-									title={printStatus}
-								>
-									{printStatus}
-								</span>
-							)}
 							{/* 音轨选择按钮（使用 IconButton 与主预览一致） */}
 							<Tooltip>
 								<TooltipTrigger asChild>

--- a/src/renderer/components/PrintWindow.tsx
+++ b/src/renderer/components/PrintWindow.tsx
@@ -271,8 +271,8 @@ export default function PrintWindow() {
 							: t("printPreparing")}
 					</div>
 				</div>
+				<div className="print-status">{status}</div>
 				<div className="print-toolbar-actions">
-					<div className="print-status">{status}</div>
 					<Button size="sm" onClick={() => window.print()}>
 						<Printer className="h-4 w-4" />
 						{t("print")}

--- a/src/renderer/components/PrintWindow.tsx
+++ b/src/renderer/components/PrintWindow.tsx
@@ -271,8 +271,8 @@ export default function PrintWindow() {
 							: t("printPreparing")}
 					</div>
 				</div>
-				<div className="print-status">{status}</div>
 				<div className="print-toolbar-actions">
+					<div className="print-status">{status}</div>
 					<Button size="sm" onClick={() => window.print()}>
 						<Printer className="h-4 w-4" />
 						{t("print")}

--- a/src/renderer/components/PrintWindow.tsx
+++ b/src/renderer/components/PrintWindow.tsx
@@ -222,6 +222,9 @@ export default function PrintWindow() {
 					-webkit-print-color-adjust: exact;
 					print-color-adjust: exact;
 				}
+				@page {
+					margin: 0;
+				}
 				.print-window-root,
 				.print-shell,
 				.print-stack {
@@ -234,7 +237,7 @@ export default function PrintWindow() {
 					display: none !important;
 				}
 				.print-shell {
-					padding: 0;
+					padding: ${payload.marginMm}mm;
 				}
 				.print-stack {
 					width: auto;


### PR DESCRIPTION
Closes #189

## Problem
Browser default headers (timestamp) and footers (URL) appeared on printed output because the \@page { margin: 15mm }\ rule reserved space where Chromium renders its automatic headers/footers.

## Fix
In \@media print\:
- \@page { margin: 0; }\ eliminates the header/footer render space
- \.print-shell { padding: \mm; }\ moves the equivalent whitespace inside the content

Visual spacing is preserved, but the browser headers/footers no longer appear.

## Verification
- \pnpm type-check\ passed
- \pnpm lint\ passed
- Print-specific tests: 6/6 passed