### PR TITLE
[codex] Fix Windows dev server port EACCES

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ pnpm dev        # Vite renderer plus the Tauri desktop shell
 pnpm dev:react  # Renderer only, using the Web runtime adapter
 ```
 
-The Vite development server listens on `127.0.0.1:7777` by default.
+The Vite development server listens on `127.0.0.1:1420` by default.
 
 ### Validate
 

--- a/public/docs/README.md
+++ b/public/docs/README.md
@@ -121,7 +121,7 @@ pnpm dev        # Vite renderer plus the Tauri desktop shell
 pnpm dev:react  # Renderer only, using the Web runtime adapter
 ```
 
-The Vite development server listens on `127.0.0.1:7777` by default.
+The Vite development server listens on `127.0.0.1:1420` by default.
 
 ### Validate
 

--- a/scripts/verify-tauri-config.mjs
+++ b/scripts/verify-tauri-config.mjs
@@ -33,7 +33,7 @@ function includesToken(value, token) {
 	return tokenize(value).includes(token);
 }
 
-function verifyCspObject(name, csp, { allowDevEval = false, requireDevHost = false } = {}) {
+function verifyCspObject(name, csp, { allowDevEval = false, devServerUrl } = {}) {
 	ensure(csp && typeof csp === "object" && !Array.isArray(csp), `${name} must be a CSP object`);
 	ensure(csp["default-src"], `${name} must define default-src`);
 	ensure(csp["script-src"], `${name} must define script-src`);
@@ -60,10 +60,13 @@ function verifyCspObject(name, csp, { allowDevEval = false, requireDevHost = fal
 	}
 	ensure(!includesToken(csp["script-src"], "'unsafe-inline'"), `${name} script-src must not allow unsafe-inline`);
 
-	if (requireDevHost) {
+	if (devServerUrl) {
+		const devServerOrigin = new URL(devServerUrl).origin;
+		const devServerWebSocketUrl = new URL(devServerOrigin);
+		devServerWebSocketUrl.protocol = devServerWebSocketUrl.protocol === "https:" ? "wss:" : "ws:";
 		ensure(
-			includesToken(csp["connect-src"], "http://127.0.0.1:7777") &&
-				includesToken(csp["connect-src"], "ws://127.0.0.1:7777"),
+			includesToken(csp["connect-src"], devServerOrigin) &&
+				includesToken(csp["connect-src"], devServerWebSocketUrl.origin),
 			`${name} connect-src must allow the local Vite dev server`,
 		);
 	}
@@ -95,7 +98,7 @@ function main() {
 	verifyCspObject("app.security.csp", tauriConfig.app?.security?.csp);
 	verifyCspObject("app.security.devCsp", tauriConfig.app?.security?.devCsp, {
 		allowDevEval: true,
-		requireDevHost: true,
+		devServerUrl: tauriConfig.build?.devUrl,
 	});
 	ensure(tauriConfig.app?.withGlobalTauri === true, "app.withGlobalTauri must be enabled for Tauri MCP bridge");
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -6,7 +6,7 @@
 	"build": {
 		"beforeDevCommand": "pnpm dev:react",
 		"beforeBuildCommand": "pnpm build:web",
-		"devUrl": "http://127.0.0.1:7777",
+		"devUrl": "http://127.0.0.1:1420",
 		"frontendDist": "../dist"
 	},
 	"app": {
@@ -34,17 +34,17 @@
 				"worker-src": "'self' blob: tauri: https://tauri.localhost"
 			},
 			"devCsp": {
-				"default-src": "'self' customprotocol: asset: http://127.0.0.1:7777 ws://127.0.0.1:7777",
+				"default-src": "'self' customprotocol: asset: http://127.0.0.1:1420 ws://127.0.0.1:1420",
 				"base-uri": "'self'",
 				"object-src": "'none'",
 				"frame-ancestors": "'none'",
-				"script-src": "'self' 'unsafe-eval' 'wasm-unsafe-eval' http://127.0.0.1:7777",
-				"style-src": "'self' 'unsafe-inline' http://127.0.0.1:7777",
-				"connect-src": "'self' ipc: http://ipc.localhost http://127.0.0.1:7777 ws://127.0.0.1:7777 https://fkasoumnkzrtqwqicbkg.supabase.co",
-				"img-src": "'self' asset: http://asset.localhost data: blob: http://127.0.0.1:7777",
-				"font-src": "'self' asset: http://asset.localhost data: blob: http://127.0.0.1:7777",
-				"media-src": "'self' asset: http://asset.localhost data: blob: http://127.0.0.1:7777",
-				"worker-src": "'self' blob: http://127.0.0.1:7777"
+				"script-src": "'self' 'unsafe-eval' 'wasm-unsafe-eval' http://127.0.0.1:1420",
+				"style-src": "'self' 'unsafe-inline' http://127.0.0.1:1420",
+				"connect-src": "'self' ipc: http://ipc.localhost http://127.0.0.1:1420 ws://127.0.0.1:1420 https://fkasoumnkzrtqwqicbkg.supabase.co",
+				"img-src": "'self' asset: http://asset.localhost data: blob: http://127.0.0.1:1420",
+				"font-src": "'self' asset: http://asset.localhost data: blob: http://127.0.0.1:1420",
+				"media-src": "'self' asset: http://asset.localhost data: blob: http://127.0.0.1:1420",
+				"worker-src": "'self' blob: http://127.0.0.1:1420"
 			}
 		},
 		"withGlobalTauri": true

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -164,7 +164,7 @@ export default defineConfig({
 	},
 	server: {
 		host: tauriDevHost || "127.0.0.1",
-		port: 7777,
+		port: 1420,
 		strictPort: true,
 		hmr: tauriDevHost
 			? {


### PR DESCRIPTION
## Summary

- move the Vite/Tauri development server from port `7777` to `1420`
- keep the Tauri development URL and development CSP origins aligned
- derive the CSP validation origin from `build.devUrl` instead of duplicating the port in the verification script
- update the root README and its generated public copy

## Root cause

On the affected Windows machine, TCP ports `7770-7869` are in the system excluded-port range. Vite therefore cannot bind `127.0.0.1:7777` and exits with `listen EACCES`, which causes Tauri's `beforeDevCommand` to fail.

## Impact

`pnpm dev` can start normally on affected Windows systems. The change only affects the development server and development CSP; production runtime configuration is unchanged.

## Validation

- `pnpm check:tauri:config`
- `pnpm docs:check`
- `pnpm lint`
- `pnpm type-check`
- `git diff --check`
- `pnpm dev` smoke test: Vite became ready on `127.0.0.1:1420`, Rust finished the dev build, and `tabst-tauri.exe` launched

`pnpm check` reaches the formatter but reports 24 pre-existing CRLF/LF differences in untouched `src` files in this Windows checkout. Those files are not part of this PR; the separate lint and TypeScript checks pass.
