### PR TITLE
[codex] fix PDF filenames and imported score tracks panel

### DIFF
--- a/src/renderer/components/Editor.tsx
+++ b/src/renderer/components/Editor.tsx
@@ -34,6 +34,7 @@ import {
 	rebindEditorAutosaveRequest,
 } from "../lib/editor-autosave";
 import { isImportableScoreFilePath } from "../lib/gp-import";
+import { shouldMountPreviewTracksPanel } from "../lib/score-workspace-layout";
 import { runUiCommand } from "../lib/ui-command-registry";
 import {
 	isWebsiteMobileLayout,
@@ -862,6 +863,10 @@ export function Editor({
 	// Determine language to optionally enable preview layout for .atex
 	const languageForActive = getLanguageForFile(activeFile.path);
 	const isImportedScoreFile = isImportableScoreFilePath(activeFile.path);
+	const mountTracksPanelInPreview = shouldMountPreviewTracksPanel({
+		isImportedScoreFile,
+		enjoyMode,
+	});
 
 	return (
 		<div className="flex-1 flex flex-col h-full overflow-hidden">
@@ -869,7 +874,7 @@ export function Editor({
 				<div className="flex-1 overflow-hidden flex">
 					<div className="w-full relative flex flex-col bg-card min-h-0 overflow-y-auto overflow-x-hidden">
 						<Preview
-							fileName={`${activeFile.name} ${t("common:preview")}`}
+							fileName={activeFile.name}
 							filePath={activeFile.path}
 							content={activeFile.content}
 							onApiChange={setPreviewApi}
@@ -881,7 +886,7 @@ export function Editor({
 							showExpandSidebar={showExpandSidebar}
 							onExpandSidebar={onExpandSidebar}
 						/>
-						{enjoyMode && (
+						{mountTracksPanelInPreview && (
 							<TracksPanel
 								api={previewApi}
 								isOpen={isTracksPanelOpen && previewApi !== null}
@@ -947,7 +952,7 @@ export function Editor({
 						className={`${enjoyMode ? "w-full" : shouldStackWebsitePreview ? "h-1/2 w-full" : "w-1/2"} relative flex flex-col bg-card min-h-0 overflow-y-auto overflow-x-hidden`}
 					>
 						<Preview
-							fileName={`${activeFile.name} ${t("common:preview")}`}
+							fileName={activeFile.name}
 							filePath={activeFile.path}
 							content={activeFile.content}
 							onApiChange={setPreviewApi}
@@ -957,7 +962,7 @@ export function Editor({
 							isEnjoyMode={enjoyMode}
 							mobileScoreFit={websiteMobileLayout}
 						/>
-						{enjoyMode && (
+						{mountTracksPanelInPreview && (
 							<TracksPanel
 								api={previewApi}
 								isOpen={isTracksPanelOpen && previewApi !== null}

--- a/src/renderer/components/Preview.tsx
+++ b/src/renderer/components/Preview.tsx
@@ -2302,7 +2302,9 @@ export default function Preview({
 							}
 							title={
 								<span className="sr-only">
-									{fileName ?? t("common:preview")}
+									{fileName
+										? `${fileName} ${t("common:preview")}`
+										: t("common:preview")}
 								</span>
 							}
 							trailing={

--- a/src/renderer/components/PrintWindow.tsx
+++ b/src/renderer/components/PrintWindow.tsx
@@ -7,6 +7,7 @@ import {
 	buildPrintFontFamilyCssValue,
 } from "../lib/print-fonts";
 import {
+	buildPrintDocumentTitle,
 	type PrintWindowPayload,
 	readPrintWindowPayload,
 } from "../lib/print-window";
@@ -18,13 +19,19 @@ export default function PrintWindow() {
 	const [status, setStatus] = useState<string>(t("printPreparing"));
 
 	useEffect(() => {
+		const previousTitle = document.title;
 		const nextPayload = readPrintWindowPayload();
 		if (!nextPayload) {
 			setStatus(t("printPrepareFailed"));
 			return;
 		}
+		document.title = buildPrintDocumentTitle(nextPayload.fileName);
 		setPayload(nextPayload);
 		setStatus(t("printWaitingForFonts"));
+
+		return () => {
+			document.title = previousTitle;
+		};
 	}, [t]);
 
 	useEffect(() => {

--- a/src/renderer/lib/print-window.test.ts
+++ b/src/renderer/lib/print-window.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+	buildPrintDocumentTitle,
 	buildPrintWindowUrl,
 	isPrintWindowLocation,
 	PRINT_WINDOW_QUERY_KEY,
@@ -7,6 +8,15 @@ import {
 } from "./print-window";
 
 describe("print-window helpers", () => {
+	it("builds the PDF document title from the source file name", () => {
+		expect(buildPrintDocumentTitle("Canon Rock.atex")).toBe("Canon Rock");
+		expect(buildPrintDocumentTitle("arrangements/song.v2.atex")).toBe(
+			"song.v2",
+		);
+		expect(buildPrintDocumentTitle("C:\\scores\\demo.gp5")).toBe("demo");
+		expect(buildPrintDocumentTitle("Untitled")).toBe("Untitled");
+	});
+
 	it("builds a same-origin app url for the dedicated print window", () => {
 		expect(
 			buildPrintWindowUrl("https://tauri.localhost/index.html?foo=1#section"),

--- a/src/renderer/lib/print-window.ts
+++ b/src/renderer/lib/print-window.ts
@@ -13,6 +13,17 @@ export interface PrintWindowPayload {
 	pagesHtml: string;
 }
 
+export function buildPrintDocumentTitle(fileName: string): string {
+	const normalizedFileName = fileName.trim().replace(/\\/g, "/");
+	const baseName = normalizedFileName.split("/").pop()?.trim() ?? "";
+	if (!baseName) return "Tabst";
+
+	const extensionIndex = baseName.lastIndexOf(".");
+	if (extensionIndex <= 0) return baseName;
+
+	return baseName.slice(0, extensionIndex).trim() || baseName;
+}
+
 export function buildPrintWindowUrl(currentHref: string): string {
 	const url = new URL(currentHref);
 	url.search = "";

--- a/src/renderer/lib/score-workspace-layout.test.ts
+++ b/src/renderer/lib/score-workspace-layout.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { shouldMountPreviewTracksPanel } from "./score-workspace-layout";
+
+describe("score workspace layout", () => {
+	it("mounts Track Selection beside imported scores outside Enjoy mode", () => {
+		expect(
+			shouldMountPreviewTracksPanel({
+				isImportedScoreFile: true,
+				enjoyMode: false,
+			}),
+		).toBe(true);
+	});
+
+	it("mounts the preview-side panel for Enjoy mode only on AlphaTex pages", () => {
+		expect(
+			shouldMountPreviewTracksPanel({
+				isImportedScoreFile: false,
+				enjoyMode: true,
+			}),
+		).toBe(true);
+		expect(
+			shouldMountPreviewTracksPanel({
+				isImportedScoreFile: false,
+				enjoyMode: false,
+			}),
+		).toBe(false);
+	});
+});

--- a/src/renderer/lib/score-workspace-layout.ts
+++ b/src/renderer/lib/score-workspace-layout.ts
@@ -1,0 +1,11 @@
+export interface PreviewTracksPanelLayoutOptions {
+	isImportedScoreFile: boolean;
+	enjoyMode: boolean;
+}
+
+export function shouldMountPreviewTracksPanel({
+	isImportedScoreFile,
+	enjoyMode,
+}: PreviewTracksPanelLayoutOptions): boolean {
+	return isImportedScoreFile || enjoyMode;
+}


### PR DESCRIPTION
## Summary

- use the active score file name as the system print/PDF document title instead of the static `Tabst` title
- keep the preview display label separate from the raw source file name used for printing
- mount Track Selection for imported GP/GPX score pages outside Enjoy mode
- preserve the existing AlphaTex split-workspace and Enjoy-mode panel placement
- add focused regression tests for print document titles and score-workspace panel placement

## Root cause

The dedicated print window received the score file name but never assigned it to `document.title`. Chromium/WebView therefore used the static application title and suggested `Tabst.pdf`.

Imported score pages toggled the global Track Selection state from the bottom bar, but only mounted `TracksPanel` in Enjoy mode. In the normal imported-score workspace the state changed without any panel component being present to render.

## User impact

- printing `Canon Rock.atex` now suggests `Canon Rock.pdf`
- GP, GP3, GP4, GP5, and GPX pages can open Track Selection in the normal workspace
- AlphaTex workspace behavior and accessible preview labeling remain intact

## Validation

- `pnpm test` — 28 test files, 115 tests passed
- `pnpm lint`
- `pnpm type-check`
- `pnpm build:web`
- targeted Biome format/lint/assist checks for all changed files
- `git diff --check`

## Follow-up

Native file-picker support for external SoundFonts and MuseScore is intentionally out of scope and tracked separately in #198.
