### PR TITLE
[codex] Add Record settings and tooltip visibility toggle

### DIFF
--- a/src/renderer/components/SettingsSidebar.tsx
+++ b/src/renderer/components/SettingsSidebar.tsx
@@ -9,6 +9,7 @@ import {
 	RefreshCw,
 	Settings,
 	Sparkles,
+	Video,
 } from "lucide-react";
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
@@ -59,6 +60,16 @@ export function SettingsSidebar() {
 							case "playback":
 								return (
 									<Play
+										className={`flex-none h-3.5 w-3.5 ${
+											activeSettingsPageId === p.id
+												? "text-[var(--highlight-text)]"
+												: "text-muted-foreground hover:text-[var(--hover-text)]"
+										}`}
+									/>
+								);
+							case "record":
+								return (
+									<Video
 										className={`flex-none h-3.5 w-3.5 ${
 											activeSettingsPageId === p.id
 												? "text-[var(--highlight-text)]"

--- a/src/renderer/components/SettingsView.tsx
+++ b/src/renderer/components/SettingsView.tsx
@@ -7,6 +7,7 @@ import { AppearancePage } from "./settings/AppearancePage";
 import { CommandsPage } from "./settings/CommandsPage";
 import { ExternalToolsPage } from "./settings/ExternalToolsPage";
 import { PlaybackPage } from "./settings/PlaybackPage";
+import { RecordPage } from "./settings/RecordPage";
 import { RoadmapPage } from "./settings/RoadmapPage";
 import { ShortcutsPage } from "./settings/ShortcutsPage";
 import { TemplatesPage } from "./settings/TemplatesPage";
@@ -56,6 +57,8 @@ export default function SettingsView({
 		switch (pageId) {
 			case "appearance":
 				return <AppearancePage />;
+			case "record":
+				return <RecordPage />;
 			case "playback":
 				return <PlaybackPage />;
 			case "commands":

--- a/src/renderer/components/settings-pages.ts
+++ b/src/renderer/components/settings-pages.ts
@@ -16,6 +16,11 @@ export const defaultSettingsPages: SettingsPage[] = [
 		description: "主题与界面显示相关设置",
 	},
 	{
+		id: "record",
+		title: "录制",
+		description: "录制视频时的界面显示设置",
+	},
+	{
 		id: "playback",
 		title: "播放", // 后备值，实际使用 t("settings:playback")
 		description: "播放速度与模式相关设置",

--- a/src/renderer/components/settings/RecordPage.tsx
+++ b/src/renderer/components/settings/RecordPage.tsx
@@ -1,0 +1,36 @@
+import { useTranslation } from "react-i18next";
+import { useAppStore } from "../../store/appStore";
+import { Switch } from "../ui/switch";
+
+export function RecordPage() {
+	const { t } = useTranslation("settings");
+	const showButtonTooltips = useAppStore((state) => state.showButtonTooltips);
+	const setShowButtonTooltips = useAppStore(
+		(state) => state.setShowButtonTooltips,
+	);
+	const label = t("recordSection.showButtonTooltips");
+
+	return (
+		<section className="bg-card border border-border rounded p-4">
+			<div className="flex items-center justify-between gap-6 rounded-lg border border-border p-3">
+				<div className="min-w-0">
+					<label
+						htmlFor="show-button-tooltips"
+						className="text-sm font-medium cursor-pointer"
+					>
+						{label}
+					</label>
+					<p className="text-xs text-muted-foreground mt-1">
+						{t("recordSection.showButtonTooltipsHint")}
+					</p>
+				</div>
+				<Switch
+					id="show-button-tooltips"
+					checked={showButtonTooltips}
+					onCheckedChange={setShowButtonTooltips}
+					aria-label={label}
+				/>
+			</div>
+		</section>
+	);
+}

--- a/src/renderer/components/ui/tooltip.test.ts
+++ b/src/renderer/components/ui/tooltip.test.ts
@@ -1,0 +1,63 @@
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const tooltipState = vi.hoisted(() => ({
+	showButtonTooltips: true,
+	contentRender: vi.fn(),
+}));
+
+vi.mock("@/renderer/store/appStore", () => ({
+	useAppStore: (
+		selector: (state: { showButtonTooltips: boolean }) => unknown,
+	) => selector(tooltipState),
+}));
+
+vi.mock("@radix-ui/react-tooltip", async () => {
+	const ReactModule = await import("react");
+	const Passthrough = ({ children }: { children?: React.ReactNode }) =>
+		ReactModule.createElement(ReactModule.Fragment, null, children);
+	const Content = ReactModule.forwardRef<
+		HTMLDivElement,
+		{ children?: React.ReactNode }
+	>(({ children }, ref) => {
+		tooltipState.contentRender();
+		return ReactModule.createElement("div", { ref }, children);
+	});
+
+	return {
+		Provider: Passthrough,
+		Root: Passthrough,
+		Trigger: Passthrough,
+		Content,
+	};
+});
+
+import { TooltipContent } from "./tooltip";
+
+describe("TooltipContent visibility", () => {
+	beforeEach(() => {
+		tooltipState.showButtonTooltips = true;
+		tooltipState.contentRender.mockClear();
+	});
+
+	it("renders tooltip content when button hints are enabled", () => {
+		const markup = renderToStaticMarkup(
+			React.createElement(TooltipContent, null, "Visible hint"),
+		);
+
+		expect(markup).toContain("Visible hint");
+		expect(tooltipState.contentRender).toHaveBeenCalledTimes(1);
+	});
+
+	it("suppresses tooltip content when button hints are disabled", () => {
+		tooltipState.showButtonTooltips = false;
+
+		const markup = renderToStaticMarkup(
+			React.createElement(TooltipContent, null, "Hidden hint"),
+		);
+
+		expect(markup).toBe("");
+		expect(tooltipState.contentRender).not.toHaveBeenCalled();
+	});
+});

--- a/src/renderer/components/ui/tooltip.tsx
+++ b/src/renderer/components/ui/tooltip.tsx
@@ -2,6 +2,7 @@ import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import * as React from "react";
 
 import { cn } from "@/renderer/lib/utils";
+import { useAppStore } from "@/renderer/store/appStore";
 
 const TooltipProvider = TooltipPrimitive.Provider;
 
@@ -12,17 +13,23 @@ const TooltipTrigger = TooltipPrimitive.Trigger;
 const TooltipContent = React.forwardRef<
 	React.ElementRef<typeof TooltipPrimitive.Content>,
 	React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
-	<TooltipPrimitive.Content
-		ref={ref}
-		sideOffset={sideOffset}
-		className={cn(
-			"z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-tooltip-content-transform-origin]",
-			className,
-		)}
-		{...props}
-	/>
-));
+>(({ className, sideOffset = 4, ...props }, ref) => {
+	const showButtonTooltips = useAppStore((state) => state.showButtonTooltips);
+
+	if (!showButtonTooltips) return null;
+
+	return (
+		<TooltipPrimitive.Content
+			ref={ref}
+			sideOffset={sideOffset}
+			className={cn(
+				"z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-tooltip-content-transform-origin]",
+				className,
+			)}
+			{...props}
+		/>
+	);
+});
 TooltipContent.displayName = TooltipPrimitive.Content.displayName;
 
 export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/src/renderer/i18n/locales/en/settings.json
+++ b/src/renderer/i18n/locales/en/settings.json
@@ -3,6 +3,8 @@
 	"backToEditor": "Back to editor",
 	"appearance": "Appearance",
 	"appearanceDesc": "Theme and display",
+	"record": "Record",
+	"recordDesc": "Recording-friendly interface options",
 	"light": "Light",
 	"dark": "Dark",
 	"system": "System",
@@ -279,6 +281,10 @@
 		"uiTheme": "UI Theme",
 		"editorTheme": "Editor Highlight",
 		"preview": "Current Selection"
+	},
+	"recordSection": {
+		"showButtonTooltips": "Show button tooltips",
+		"showButtonTooltipsHint": "Turn this off while recording to prevent button hints from covering the content. Button accessibility labels remain available."
 	},
 	"playbackSection": {
 		"experimental": "Experimental",

--- a/src/renderer/i18n/locales/zh-cn/settings.json
+++ b/src/renderer/i18n/locales/zh-cn/settings.json
@@ -3,6 +3,8 @@
 	"backToEditor": "返回编辑器",
 	"appearance": "外观",
 	"appearanceDesc": "主题与界面显示相关设置",
+	"record": "录制",
+	"recordDesc": "适合视频录制的界面显示设置",
 	"light": "浅色",
 	"dark": "深色",
 	"system": "跟随系统",
@@ -279,6 +281,10 @@
 		"uiTheme": "界面主题",
 		"editorTheme": "编辑器高亮",
 		"preview": "当前选择"
+	},
+	"recordSection": {
+		"showButtonTooltips": "显示按钮提示",
+		"showButtonTooltipsHint": "录制视频时可关闭此项，避免按钮提示遮挡内容；按钮的无障碍标签仍会保留。"
 	},
 	"playbackSection": {
 		"experimental": "试验性",

--- a/src/renderer/lib/global-settings.test.ts
+++ b/src/renderer/lib/global-settings.test.ts
@@ -7,6 +7,7 @@ interface TestDesktopApi {
 	loadWorkspaceMetadata: ReturnType<typeof vi.fn>;
 	saveWorkspaceMetadata: ReturnType<typeof vi.fn>;
 	loadGlobalSettings: ReturnType<typeof vi.fn>;
+	saveGlobalSettings: ReturnType<typeof vi.fn>;
 }
 
 function installDesktopApi(api: TestDesktopApi) {
@@ -26,6 +27,7 @@ describe("workspace-backed global settings", () => {
 			loadWorkspaceMetadata: vi.fn(),
 			saveWorkspaceMetadata: vi.fn(),
 			loadGlobalSettings: vi.fn(),
+			saveGlobalSettings: vi.fn(),
 		};
 		installDesktopApi(desktopApi);
 		setActiveRepoContext(null);
@@ -59,6 +61,7 @@ describe("workspace-backed global settings", () => {
 		expect(result).toEqual({
 			locale: "en",
 			deleteBehavior: "repo-trash",
+			showButtonTooltips: true,
 			theme: {
 				uiThemeId: "catppuccin",
 				editorThemeId: "catppuccin",
@@ -86,7 +89,42 @@ describe("workspace-backed global settings", () => {
 
 		expect(result.locale).toBe("en");
 		expect(result.deleteBehavior).toBe("system-trash");
+		expect(result.showButtonTooltips).toBe(true);
 		expect(desktopApi.loadGlobalSettings).toHaveBeenCalledTimes(1);
+	});
+
+	it("loads the tooltip preference from global settings", async () => {
+		desktopApi.loadGlobalSettings.mockResolvedValue({
+			success: true,
+			data: {
+				showButtonTooltips: false,
+			},
+		});
+
+		const result = await loadGlobalSettings();
+
+		expect(result.showButtonTooltips).toBe(false);
+	});
+
+	it("saves the tooltip preference globally without dropping other fields", async () => {
+		desktopApi.loadGlobalSettings.mockResolvedValue({
+			success: true,
+			data: {
+				locale: "en",
+				futureSetting: "preserved",
+			},
+		});
+		desktopApi.saveGlobalSettings.mockResolvedValue({ success: true });
+
+		const ok = await saveGlobalSettings({ showButtonTooltips: false });
+
+		expect(ok).toBe(true);
+		expect(desktopApi.saveGlobalSettings).toHaveBeenCalledWith({
+			locale: "en",
+			futureSetting: "preserved",
+			showButtonTooltips: false,
+		});
+		expect(desktopApi.saveWorkspaceMetadata).not.toHaveBeenCalled();
 	});
 
 	it("saves merged settings into workspace metadata", async () => {

--- a/src/renderer/lib/global-settings.ts
+++ b/src/renderer/lib/global-settings.ts
@@ -9,6 +9,7 @@ import {
 const DEFAULT_SETTINGS: GlobalSettings = {
 	locale: "zh-cn",
 	deleteBehavior: "ask-every-time",
+	showButtonTooltips: true,
 	theme: {
 		uiThemeId: "github",
 		editorThemeId: "github",
@@ -71,6 +72,11 @@ async function loadLegacyGlobalSettings(): Promise<GlobalSettings | null> {
 				(response.data as GlobalSettings).deleteBehavior ??
 				DEFAULT_SETTINGS.deleteBehavior,
 			theme: (response.data as GlobalSettings).theme ?? DEFAULT_SETTINGS.theme,
+			showButtonTooltips:
+				typeof (response.data as GlobalSettings).showButtonTooltips ===
+				"boolean"
+					? (response.data as GlobalSettings).showButtonTooltips
+					: DEFAULT_SETTINGS.showButtonTooltips,
 		};
 	} catch (error) {
 		console.error("Failed to load legacy global settings:", error);
@@ -107,6 +113,8 @@ export async function loadGlobalSettings(): Promise<GlobalSettings> {
 				workspaceSettings.deleteBehavior,
 			theme:
 				metadata.preferences?.theme ?? legacy?.theme ?? workspaceSettings.theme,
+			showButtonTooltips:
+				legacy?.showButtonTooltips ?? DEFAULT_SETTINGS.showButtonTooltips,
 		};
 	} catch (error) {
 		console.error("Failed to load workspace settings:", error);
@@ -114,9 +122,54 @@ export async function loadGlobalSettings(): Promise<GlobalSettings> {
 	}
 }
 
+async function saveLegacyGlobalSettings(
+	partial: Partial<GlobalSettings>,
+): Promise<boolean> {
+	if (
+		!window.desktopAPI?.loadGlobalSettings ||
+		!window.desktopAPI?.saveGlobalSettings
+	) {
+		return false;
+	}
+
+	try {
+		const response = await window.desktopAPI.loadGlobalSettings();
+		const current =
+			response?.success && response.data && typeof response.data === "object"
+				? (response.data as Record<string, unknown>)
+				: {};
+		const result = await window.desktopAPI.saveGlobalSettings({
+			...current,
+			...partial,
+		});
+		return result.success;
+	} catch (error) {
+		console.error("Failed to save legacy global settings:", error);
+		return false;
+	}
+}
+
 export async function saveGlobalSettings(
 	partial: Partial<GlobalSettings>,
 ): Promise<boolean> {
+	let globalSettingsSaved = true;
+	if (typeof partial.showButtonTooltips === "boolean") {
+		globalSettingsSaved = await saveLegacyGlobalSettings({
+			showButtonTooltips: partial.showButtonTooltips,
+		});
+	}
+
+	const workspacePartial: Partial<GlobalSettings> = {};
+	if (partial.locale !== undefined) workspacePartial.locale = partial.locale;
+	if (partial.deleteBehavior !== undefined) {
+		workspacePartial.deleteBehavior = partial.deleteBehavior;
+	}
+	if (partial.theme !== undefined) workspacePartial.theme = partial.theme;
+
+	if (Object.keys(workspacePartial).length === 0) {
+		return globalSettingsSaved;
+	}
+
 	const activeRepo = getActiveRepoContext();
 	if (!activeRepo) {
 		return false;
@@ -138,7 +191,7 @@ export async function saveGlobalSettings(
 				expandedFolders: existingMetadata?.expandedFolders ?? [],
 				preferences: mergeSettingsIntoPreferences(
 					existingMetadata?.preferences,
-					partial,
+					workspacePartial,
 				),
 				activeFilePath: existingMetadata?.activeFilePath ?? null,
 				workspaceMode: existingMetadata?.workspaceMode,
@@ -149,7 +202,7 @@ export async function saveGlobalSettings(
 
 			return nextMetadata;
 		});
-		return true;
+		return globalSettingsSaved;
 	} catch (error) {
 		console.error("Failed to save workspace settings:", error);
 		return false;

--- a/src/renderer/store/appStore.ts
+++ b/src/renderer/store/appStore.ts
@@ -707,6 +707,8 @@ interface AppState {
 	// i18n 语言
 	locale: "en" | "zh-cn";
 	setLocale: (locale: "en" | "zh-cn") => void;
+	showButtonTooltips: boolean;
+	setShowButtonTooltips: (show: boolean) => void;
 	disabledCommandIds: string[];
 	setCommandEnabled: (commandId: string, enabled: boolean) => void;
 	pinnedCommandIds: string[];
@@ -2085,6 +2087,11 @@ export const useAppStore = create<AppState>((set, get) => ({
 		});
 		void saveGlobalSettings({ locale });
 	},
+	showButtonTooltips: true,
+	setShowButtonTooltips: (show) => {
+		set({ showButtonTooltips: show });
+		void saveGlobalSettings({ showButtonTooltips: show });
+	},
 
 	disabledCommandIds: [],
 	setCommandEnabled: (commandId, enabled) => {
@@ -2680,11 +2687,17 @@ export const useAppStore = create<AppState>((set, get) => ({
 		try {
 			isRestoringAppState = true;
 			setActiveRepoContext(null);
-			const [loadedRepos, legacyAppState, appVersion] = await Promise.all([
-				window.desktopAPI?.loadRepos?.(),
-				window.desktopAPI?.loadAppState?.(),
-				window.desktopAPI?.getAppVersion?.(),
-			]);
+			const [loadedRepos, legacyAppState, appVersion, globalSettings] =
+				await Promise.all([
+					window.desktopAPI?.loadRepos?.(),
+					window.desktopAPI?.loadAppState?.(),
+					window.desktopAPI?.getAppVersion?.(),
+					loadGlobalSettings(),
+				]);
+
+			set({
+				showButtonTooltips: globalSettings.showButtonTooltips ?? true,
+			});
 
 			if (!loadedRepos) return;
 
@@ -2795,6 +2808,12 @@ void (async () => {
 			settings.deleteBehavior !== store.deleteBehavior
 		) {
 			store.setDeleteBehavior(settings.deleteBehavior);
+		}
+		if (
+			typeof settings.showButtonTooltips === "boolean" &&
+			settings.showButtonTooltips !== store.showButtonTooltips
+		) {
+			store.setShowButtonTooltips(settings.showButtonTooltips);
 		}
 	} catch (error) {
 		console.error("Failed to hydrate initial settings:", error);

--- a/src/renderer/types/settings.ts
+++ b/src/renderer/types/settings.ts
@@ -10,4 +10,5 @@ export interface GlobalSettings {
 	locale?: "en" | "zh-cn";
 	deleteBehavior?: "system-trash" | "repo-trash" | "ask-every-time";
 	theme?: ThemePreference;
+	showButtonTooltips?: boolean;
 }


### PR DESCRIPTION
## What changed

- add a new Record settings page
- add a global Show button tooltips preference, enabled by default
- suppress shared visual tooltip content when the preference is disabled
- persist the preference through the existing global settings backend
- add English and Simplified Chinese copy
- add regression tests for persistence and tooltip rendering

## Why

Button tooltips are useful during normal editing, but they can cover score or editor content while recording videos. The new setting lets users hide the visual hints without removing button accessibility labels.

## Impact

Existing behavior is unchanged by default. Users who record videos can disable button tooltips from Settings > Record, and the preference survives an application reload.

## Validation

- `pnpm check`
- `pnpm test` — 29 test files, 119 tests passed
- `pnpm build:web`
- browser interaction check for enabled, disabled, and persisted states
- `git diff --check`

Closes #199
