### PR TITLE
chore(release): bump version to 0.7.0-rc.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "tabst",
 	"productName": "Tabst",
-	"version": "0.7.0-rc",
+	"version": "0.7.0-rc.1",
 	"description": "A minimal Guitar Tabs typewriter.",
 	"type": "module",
 	"scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tabst-tauri"
-version = "0.7.0-rc"
+version = "0.7.0-rc.1"
 description = "Tabst Tauri runtime"
 authors = ["Jay Bridge"]
 license = "MPL-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Tabst",
-	"version": "0.7.0-rc",
+	"version": "0.7.0-rc.1",
 	"identifier": "app.tabst.desktop",
 	"build": {
 		"beforeDevCommand": "pnpm dev:react",


### PR DESCRIPTION
Bump app version to 0.7.0-rc.1 (tag matches the release workflow `*.*.*-rc.*` pattern).