### PR TITLE
fix: report keep-awake as unsupported instead of faking success

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4305,7 +4305,7 @@ dependencies = [
 
 [[package]]
 name = "tabst-tauri"
-version = "0.7.0-rc"
+version = "0.7.0-rc.1"
 dependencies = [
  "dirs 5.0.1",
  "hex",

--- a/src-tauri/src/power_commands.rs
+++ b/src-tauri/src/power_commands.rs
@@ -103,9 +103,11 @@ pub(crate) fn set_keep_awake(
     {
         let _ = keep_awake_manager;
         let _ = enabled;
+        // Report honestly instead of faking success: the keep-awake power
+        // assertion is currently only implemented on macOS.
         BasicResult {
-            success: true,
-            error: None,
+            success: false,
+            error: Some("keep-awake-unsupported".to_string()),
         }
     }
 }

--- a/src/renderer/components/Preview.tsx
+++ b/src/renderer/components/Preview.tsx
@@ -575,7 +575,7 @@ export default function Preview({
 			.then((result) => {
 				if (isCancelled) return;
 				if (result.success) return;
-				if (result.error === "Unsupported in web runtime") return;
+				if (result.error === "keep-awake-unsupported") return;
 				console.warn(
 					"[Preview] Failed to update keep-awake state:",
 					result.error ?? "unknown-error",

--- a/src/renderer/lib/desktop-api.ts
+++ b/src/renderer/lib/desktop-api.ts
@@ -588,7 +588,10 @@ export function createWebDesktopAPI(): DesktopAPI {
 			error: "Unsupported in web runtime",
 		}),
 
-		setKeepAwake: async (_enabled: boolean) => ({ success: true }),
+		setKeepAwake: async () => ({
+			success: false,
+			error: "keep-awake-unsupported",
+		}),
 	};
 
 	return api;


### PR DESCRIPTION
The non-macOS Tauri path and the web runtime returned success:true
without applying any power assertion, so users believed the setting was
active. Both paths now return success:false with the shared
'keep-awake-unsupported' error code, and the preview call site stops
silently swallowing only the web-specific message in favor of the
shared code.

Fixes #128
