### PR TITLE
fix(audio): focus/visibility stutter, sleep-induced audio loss, and restart notice

### DIFF
--- a/docs/dev/architecture/PREVIEW_LIFECYCLE.md
+++ b/docs/dev/architecture/PREVIEW_LIFECYCLE.md
@@ -55,7 +55,7 @@ The main owners are:
 | Shared destroy and print suspension/resume | `hooks/usePreviewApiLifecycle.ts` |
 | Parse timeout and last-valid-score recovery | `hooks/usePreviewErrorRecovery.ts` |
 | Lifecycle counters and state transitions | `hooks/usePreviewLifecycleTelemetry.ts` |
-| Theme palette lookup and class observer | `lib/themeManager.ts` |
+| Theme palette lookup | `lib/themeManager.ts` |
 | Staff display mutation | `lib/staff-config.ts` |
 | Editor-to-score synchronization | `hooks/usePreviewSelectionSync.ts` |
 | Bar-number highlighting | `hooks/usePreviewBarHighlight.ts` |
@@ -75,7 +75,6 @@ parse ATDOC and synchronize store-facing settings
     → announce the new API instance
     → apply global playback preferences
     → bind all alphaTab listeners
-    → install the theme class observer
     → load SoundFont
     → strip ATDOC and call tex(cleanContent)
     → scoreLoaded applies document/session configuration
@@ -165,31 +164,15 @@ That refresh:
 This explicit theme-system refresh is the production path for palette changes,
 including switching between two themes that use the same light/dark mode.
 
-### Class observer fallback
+### Class observer fallback (removed)
 
-`setupThemeObserver()` observes changes to the root `class` attribute. Its
-Preview callback:
-
-1. requires a live API and non-empty content;
-2. applies a 250 ms rebuild cooldown;
-3. captures the current first-staff display flags;
-4. captures the latest clean AlphaTex content;
-5. destroys the current API and listeners;
-6. creates a new API with freshly read score colors;
-7. reapplies playback preferences;
-8. rebinds listeners;
-9. reloads SoundFont;
-10. calls `tex()` with the captured content.
-
-The observer is a compatibility fallback for external root-class changes. It
-must not be treated as the sole theme notification mechanism because:
-
-- it observes `class`, not inline CSS variable changes;
-- normal theme application already calls explicit Preview Refresh;
-- the destroy helper disconnects the observer attached to the old API.
-
-If this path is refactored, choose one authoritative notification mechanism and
-keep only a clearly documented fallback.
+An earlier implementation installed a `MutationObserver` on the root `class`
+attribute (`setupThemeObserver`) as a second rebuild path. It was removed
+because it created dual ownership: palette switches (inline CSS variables only)
+never reached it, light/dark switches could rebuild twice, and a rebuilt API
+never reinstalled the observer ("works only once"). Theme changes now have a
+single authoritative path: theme-store change → `use-theme` writes variables →
+explicit Preview `refresh()`.
 
 ## Staff display contract
 
@@ -253,7 +236,7 @@ unconditionally preserved. A regression test should cover:
 | Count-in | API remains | Reapplied | Reapplied |
 | Metronome-only track muting | Reapplied after score load | Reapplied after score load | Reapplied after score load |
 | ATDOC warm/hot/mix/color | Reapplied after score load | Reapplied after score load | Reapplied after score load |
-| First-track staff display | Reapplied from ATDOC/ref; known gap after UI toggle | Observer path snapshots; explicit Refresh has known gap | Ref survives, but may be stale |
+| First-track staff display | Reapplied from ATDOC/ref | Captured before destroy, then reapplied | Ref survives; kept in sync on UI toggle |
 | Playback position | Not guaranteed across reparse | Not restored | Reset |
 | Playing/paused state | Not guaranteed across reparse | Not restored | Stopped/reset |
 | Score selection | Cleared | Cleared | Cleared |
@@ -305,6 +288,45 @@ Two errors have narrower handling:
 - a known non-guitar TAB probe failure silently rolls back the probe;
 - a numbered-notation beat rendering failure disables numbered notation,
   rerenders, and avoids surfacing a fatal parse error when rollback succeeds.
+
+## Audio output recovery
+
+Playback audio recovery is owned by `lib/preview-audio-refresh.ts`
+(`createPlaybackAudioRefreshCoordinator`). `window.focus` and
+`visibilitychange` funnel into a single-flight `refresh()` so one window
+return runs recovery exactly once.
+
+Recovery is cascading:
+
+1. `prepareAlphaTabAudioForPlayback` (`lib/player-audio-recovery.ts`) inspects
+   the AudioContext state:
+   - `running` → return immediately (alphaTab's `activate()` only invokes its
+     callback after resuming a suspended context, so calling it while running
+     just burns a timeout);
+   - `suspended`/`interrupted`/missing context → `activate()` + direct
+     `resume()`;
+   - `closed` → report unrecoverable, do not attempt in place.
+2. The soundfont is reloaded (`append=false`, per-URL in-flight dedup) only
+   when the context is `closed`, an activation attempt did not end in
+   `running`, or playback is stalled (tick position not advancing while
+   playing). Idle time alone never triggers a reload.
+3. After a reload, playback is checked again. If it is still stalled, the
+   coordinator reports `audioStalled` and Preview shows a user-facing notice
+   with a restart action.
+
+`play()` additionally runs a self-healing check: if playback started but the
+tick position does not advance within 2 seconds, the same cascade runs.
+
+### Known platform limitation
+
+After macOS display/system sleep the WKWebView audio subsystem can stop
+working even though `AudioContext.state` reports `running` and
+`api.play()` returns success. This is a WebView process-level fault that
+cannot be repaired from inside the page (page reload, API rebuild, output-mode
+switch, and soundfont reload all fail). The only working recovery is a fresh
+WebView process, i.e. restarting the app; workspace state is restored through
+the existing autosave and session-recovery mechanisms. See
+`docs/dev/reports/WKWEBVIEW_AUDIO_SLEEP_DIAGNOSIS.md` for the full diagnosis.
 
 ## Lifecycle telemetry
 

--- a/docs/dev/reports/WKWEBVIEW_AUDIO_SLEEP_DIAGNOSIS.md
+++ b/docs/dev/reports/WKWEBVIEW_AUDIO_SLEEP_DIAGNOSIS.md
@@ -1,0 +1,137 @@
+# WKWebView 音频在显示器/系统睡眠后失效诊断报告
+
+> **Status:** Active — 2026-08-02 诊断结论，与当前 `dev` 分支实现（
+> `fix/audio-focus-stutter` 之后）一致。结论与数据来自真实运行实例的实测，
+> 不是推测。
+
+## 背景
+
+用户报告两类问题：
+
+1. **卡顿**：播放中窗口失焦再聚焦（切到 Finder 再切回）时，可听到明显的
+   音频断续。同行诊断报告定位到 4 个音频生命周期问题（详见后文）。
+2. **无声**：长期不操作（去干别的事情或单纯待机）后，再点击播放没有声音。
+
+修复卡顿后，无声问题回归——本报告记录了为定位无声根因所做的完整诊断，
+以及两个问题最终统一的根因。
+
+## 诊断方法
+
+- 环境：`pnpm dev:tauri` 运行的 debug 构建（`target/debug/tabst-tauri`），
+  MCP Bridge 注入（`tauri-plugin-mcp-bridge`，端口 9223）。
+- 工具：
+  - Tauri MCP（DOM 操作、真实鼠标事件点击、webview console 日志读取）
+  - `osascript`（Finder 窗口切换、按 PID 激活指定实例窗口）
+  - `pmset displaysleepnow`（显示器睡眠模拟）
+  - `afplay`（系统音频健康检查）
+- 测量指标：
+  - 播放进度条 tick 值是否随时间推进（`input[type=range]` 的 value）
+  - console 日志中的 `api.play() invoked {didPlay, isReadyForPlayback, tickPosition}`
+  - 探针日志 `audio recovery {initialState, finalState, didAttemptActivation}`（
+    恢复流程中读取的 AudioContext 状态）
+- 注意：**本机同时安装了 release 版 Tabst（`/Applications/Tabst.app`）与
+  dev 版**，两者同名。窗口切换实验必须按 PID 激活 dev 实例
+  （`System Events` → `set frontmost of first process whose unix id is <PID>`），
+  否则事件会落到 release 窗口。
+
+## 实验矩阵与结果
+
+### A. 窗口失焦/返回（页面事件路径）
+
+| 实验 | 结果 |
+| --- | --- |
+| 播放中切到 Finder 15 秒再切回 | 正常（播放继续，无中断） |
+| 播放中失焦 5 分钟（Finder 前台，系统未睡眠）再切回 | 正常（tick 持续推进） |
+| 停止播放 → 空闲 5 分钟 → 切回 → 点播放 | 正常（tick 从 0 推进） |
+
+结论：**窗口失焦级 idle 不影响音频**。`focus`/`visibilitychange` 触发的
+恢复路径（协调器 `createPlaybackAudioRefreshCoordinator`）工作正常，
+`AudioContext` 在这些场景下保持 `running`。
+
+### B. 显示器睡眠（`pmset displaysleepnow`，2 分钟）
+
+| 实验 | 结果 |
+| --- | --- |
+| 唤醒后点播放 | **卡死**：`api.play() invoked {didPlay:true, isReadyForPlayback:true, tickPosition:472081}`，tick 不再推进（= 无声） |
+| 卡死后页面 `location.reload()`（全新 API + 全新 worklet） | 依然卡死 |
+| 卡死后把 outputMode 切回 `WebAudioScriptProcessor`（HMR 重建 API） | 依然卡死 |
+| 卡死后杀 `WebContent` 进程（期望 WebKit 自动重生） | webview 页面挂起，不自动恢复 |
+| **完全重启 app（新 webview 进程）** | **恢复**（tick 正常推进） |
+
+### C. 关键探针数据（卡死现场）
+
+```
+audio recovery {"didAttemptActivation":false,"initialState":"running","finalState":"running"}
+api.play() invoked {"didPlay":true,"isReadyForPlayback":true,"tickPosition":472081}
+```
+
+- `AudioContext.state` = `running`（不是 suspended/interrupted/closed）
+- `isReadyForPlayback` = `true`（`isReady && isSoundFontLoaded && _isMidiLoaded`
+  全是静态标志，睡眠不影响）
+- `play()` 返回 `true`，合成器状态 `Playing`，但 tick 不推进
+- 系统音频正常（`afplay /System/Library/Sounds/Ping.aiff` 有声音）
+
+## 根因结论
+
+**macOS 显示器/系统睡眠后，WKWebView 的音频输出子系统（webview 进程级）
+损坏：`AudioContext` 状态仍为 `running`，但音频输出（worklet 样本请求或
+ScriptProcessor 回调）不再工作，alphaTab 合成器没有样本请求驱动，
+tick 停止推进。**
+
+- 与 `outputMode` 无关（worklet 与 ScriptProcessor 在睡眠后同样失效）。
+- 与 SoundFont 加载无关（重载字体、重建 API、页面 reload 均无法恢复）。
+- 唯一有效恢复手段：**重启 webview 进程（即重启应用）**。
+- 该缺陷由 WebKit 的 sleep/wake 音频会话恢复问题导致，页面内 JS 无法绕过。
+
+### 与历史修复的关系
+
+旧代码（0.7.0-rc.1 之前）在 `refreshPlaybackAudioPipeline` 里设置了
+"空闲超过 2 分钟就重载 SoundFont"（`AUDIO_IDLE_REFRESH_THRESHOLD_MS`），
+当时被认为修复了"长期不操作后无声"。本诊断证明该修复**从未真正解决无声**
+——重载 SoundFont 是页面内操作，对 webview 进程级损坏无效。它只是引入了
+副作用：每次长 idle 返回都会触发 31MB SoundFont 重载（`loadSoundFont` 内部
+先 `pause()`），叠加 focus/visibility 双恢复与 150ms 等待，成为卡顿的
+主要来源。
+
+因此：卡顿修复（删除 idle 重载、single-flight、running 不等待）是正确的；
+无声回归只是因为旧补丁本就没治本。
+
+## 已实施修复（`fix/audio-focus-stutter`）
+
+1. 删除 `outputMode: WebAudioScriptProcessor` 强制，恢复 alphaTab 默认
+   worklet 优先、自动降级。
+2. `prepareAlphaTabAudioForPlayback`：`running` 直接返回（不调用 activate、
+   不白等 150ms）；`suspended/interrupted` 单次恢复；`closed` 报告不可恢复。
+3. 新增 `preview-audio-refresh.ts` 协调器：focus/visibilitychange 共用
+   single-flight 恢复入口；仅在 `closed` 或"激活尝试未到 running"时重载
+   SoundFont；idle 时长本身不再触发任何操作。
+4. `loadSoundFontFromUrl`：`append=false`（替换而非堆积）+ per-URL in-flight
+   去重。
+
+## 后续修复方向（睡眠场景）
+
+页面内无法恢复 webview 音频，方案为"检测 + 提示 + 手动重启"：
+
+1. **播放自愈检测**：`play()` 后约 2 秒验证 tick 是否推进；播放中恢复时
+   检查 tick 是否停滞（stalled）。
+2. **级联恢复**：先 resume（覆盖窗口失焦场景）→ 重载 SoundFont（低成本
+   尝试一次）→ 仍卡死则判定为 webview 音频失效。
+3. **用户提示 + 手动重启**：弹窗提示"音频输出异常"，提供重启应用按钮
+   （Rust `restart_app` 命令：spawn 当前可执行文件后退出，工作区经 autosave
+   与会话恢复机制还原）。不自动重启。
+
+## 复现路径（回归验证用）
+
+1. `pnpm dev:tauri` 启动 dev 构建，打开任意长曲目播放。
+2. `pmset displaysleepnow`，等待 2 分钟以上。
+3. 唤醒显示器（任意鼠标/键盘活动），点击播放。
+4. 预期：tick 卡死（无声）→ 出现恢复提示 → 点击重启按钮 → 重启后播放正常。
+
+## 相关文件
+
+- `src/renderer/lib/alphatab-config.ts` — 播放器配置（outputMode）
+- `src/renderer/lib/player-audio-recovery.ts` — AudioContext 恢复逻辑
+- `src/renderer/lib/preview-audio-refresh.ts` — 刷新协调器（single-flight）
+- `src/renderer/components/Preview.tsx` — 播放/恢复编排
+- `src/renderer/lib/assets.ts` — SoundFont 加载（append=false + 去重）
+- `src-tauri/src/power_commands.rs` — 既有 keep-awake 命令（同目录参考）

--- a/src-tauri/src/app_commands.rs
+++ b/src-tauri/src/app_commands.rs
@@ -1,0 +1,42 @@
+use std::time::Duration;
+
+use crate::{to_error, BasicResult};
+
+/// 重启应用：spawn 当前可执行文件的新实例，然后退出当前进程。
+///
+/// 用于恢复 macOS 显示器/系统睡眠后失效的 WKWebView 音频输出（页面内
+/// 无法修复）。工作区状态由 autosave 与会话恢复机制还原。
+#[tauri::command]
+pub(crate) fn restart_app(app: tauri::AppHandle) -> BasicResult {
+    let exe = match std::env::current_exe() {
+        Ok(path) => path,
+        Err(error) => {
+            return BasicResult {
+                success: false,
+                error: Some(to_error(error)),
+            };
+        }
+    };
+
+    let args: Vec<String> = std::env::args().skip(1).collect();
+
+    let child = std::process::Command::new(&exe).args(&args).spawn();
+    match child {
+        Ok(_) => {
+            let handle = app.clone();
+            std::thread::spawn(move || {
+                // 给新实例一点启动时间，避免音频资源竞争
+                std::thread::sleep(Duration::from_millis(400));
+                handle.exit(0);
+            });
+            BasicResult {
+                success: true,
+                error: None,
+            }
+        }
+        Err(error) => BasicResult {
+            success: false,
+            error: Some(to_error(error)),
+        },
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod app_commands;
 mod fs_commands;
 mod git_commands;
 mod models;
@@ -8,6 +9,7 @@ mod settings_commands;
 mod support;
 mod updater_commands;
 
+use app_commands::restart_app;
 use fs_commands::{
     create_file, create_folder, load_app_state, move_path, open_external, open_file, read_asset,
     read_file, read_file_bytes, rename_file, reveal_in_folder, save_app_state, save_binary_file,
@@ -79,7 +81,8 @@ pub fn run() {
             validate_musescore_executable,
             save_musescore_executable_path,
             convert_gp_to_mxl,
-            set_keep_awake
+            set_keep_awake,
+            restart_app
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -15,6 +15,7 @@ import {
 
 const TutorialView = lazy(() => import("./components/TutorialView"));
 
+import { AudioRecoveryToast } from "./components/AudioRecoveryToast";
 import UpdateToast from "./components/UpdateToast";
 import { useFileOperations } from "./hooks/useFileOperations";
 import { getAlphaTexHighlight } from "./lib/alphatex-highlight";
@@ -664,6 +665,7 @@ function App() {
 			</div>
 
 			<UpdateToast />
+			<AudioRecoveryToast />
 			{quickSwitcherOpen && (
 				<Suspense fallback={null}>
 					<QuickFileSwitcher

--- a/src/renderer/components/AudioRecoveryToast.tsx
+++ b/src/renderer/components/AudioRecoveryToast.tsx
@@ -1,0 +1,55 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useAppStore } from "../store/appStore";
+import { Button } from "./ui/button";
+
+/**
+ * 音频输出异常提示：睡眠后 WKWebView 音频子系统失效（页面内无法恢复），
+ * 提示用户通过重启应用恢复播放。
+ */
+export function AudioRecoveryToast() {
+	const { t } = useTranslation("audio");
+	const [restarting, setRestarting] = useState(false);
+	const noticeAt = useAppStore((s) => s.audioStalledNoticeAt);
+	const setAudioStalledNoticeAt = useAppStore((s) => s.setAudioStalledNoticeAt);
+
+	if (noticeAt === null) return null;
+
+	const handleRestart = async () => {
+		if (restarting) return;
+		setRestarting(true);
+		try {
+			const result = await window.desktopAPI.restartApp();
+			if (!result.success) {
+				setRestarting(false);
+			}
+		} catch {
+			setRestarting(false);
+		}
+	};
+
+	return (
+		<div className="fixed bottom-4 right-4 z-50 w-80 rounded-lg border border-border bg-card p-4 shadow-lg">
+			<div className="flex items-start justify-between gap-3">
+				<div className="space-y-1">
+					<p className="text-sm font-medium">{t("recoveryToast.title")}</p>
+				</div>
+				<Button
+					variant="ghost"
+					size="sm"
+					onClick={() => setAudioStalledNoticeAt(null)}
+				>
+					{t("recoveryToast.dismiss")}
+				</Button>
+			</div>
+
+			<div className="mt-2 text-sm">{t("recoveryToast.message")}</div>
+
+			<div className="mt-4 flex items-center gap-2">
+				<Button onClick={() => void handleRestart()} disabled={restarting}>
+					{t("recoveryToast.restart")}
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/src/renderer/components/Preview.tsx
+++ b/src/renderer/components/Preview.tsx
@@ -65,6 +65,10 @@ import {
 	primeAlphaTabAudioOnUserGesture,
 } from "../lib/player-audio-recovery";
 import {
+	createPlaybackAudioRefreshCoordinator,
+	type PlaybackAudioRefreshCoordinator,
+} from "../lib/preview-audio-refresh";
+import {
 	PREVIEW_COMMAND_EVENT,
 	type PreviewCommandId,
 } from "../lib/preview-command-events";
@@ -111,8 +115,6 @@ type PlaybackCursorSnapshot = {
 	barIndex: number;
 	beatIndex: number;
 };
-
-const AUDIO_IDLE_REFRESH_THRESHOLD_MS = 2 * 60 * 1000;
 
 const PrintPreview = lazy(() => import("./PrintPreview"));
 
@@ -350,7 +352,6 @@ export default function Preview({
 		useRef<PlaybackFrameGate<PlaybackProgressSnapshot> | null>(null);
 	const playbackCursorGateRef =
 		useRef<PlaybackFrameGate<PlaybackCursorSnapshot> | null>(null);
-	const lastPlaybackActivityAtRef = useRef<number>(Date.now());
 
 	useEffect(() => {
 		playbackProgressGateRef.current = createPlaybackFrameGate(
@@ -775,46 +776,82 @@ export default function Preview({
 		[applyScoreTracksMuted],
 	);
 
-	const refreshPlaybackAudioPipeline = useCallback(
-		async (reason: string) => {
-			const api = apiRef.current;
-			if (!api) return;
+	// 最新的音频恢复依赖，供单一刷新协调器动态取用（避免闭包捕获旧函数实例）
+	const refreshAudioDepsRef = useRef({
+		recoverPlaybackAudio,
+		reapplyPlaybackAudioState,
+	});
+	refreshAudioDepsRef.current = {
+		recoverPlaybackAudio,
+		reapplyPlaybackAudioState,
+	};
 
-			const recovery = await recoverPlaybackAudio();
-			if (apiRef.current !== api) return;
-			const idleTooLong =
-				Date.now() - lastPlaybackActivityAtRef.current >=
-				AUDIO_IDLE_REFRESH_THRESHOLD_MS;
-			const shouldReloadSoundFont =
-				idleTooLong ||
-				recovery?.initialState === "suspended" ||
-				recovery?.initialState === "interrupted" ||
-				(recovery?.didAttemptActivation === true &&
-					recovery.finalState !== "running");
+	// 音频管线刷新协调器：focus/visibilitychange 共用同一 single-flight 入口，
+	// 同一窗口返回只执行一次恢复；级联恢复（resume → 重载 SoundFont），
+	// 播放卡死（tick 停滞）时仍无法恢复则上报 audioStalled，由 UI 提示重启。
+	const playbackAudioRefreshRef =
+		useRef<PlaybackAudioRefreshCoordinator | null>(null);
+	if (playbackAudioRefreshRef.current === null) {
+		playbackAudioRefreshRef.current = createPlaybackAudioRefreshCoordinator({
+			getApi: () => apiRef.current,
+			getRecoverPlaybackAudio: () =>
+				refreshAudioDepsRef.current.recoverPlaybackAudio,
+			reloadSoundFont: async (api) => {
+				const soundFontUrl = currentSoundFontUrlRef.current;
+				if (!soundFontUrl) return false;
+				const ok = await loadSoundFontFromUrl(api, soundFontUrl);
+				if (ok) {
+					console.info("[Preview] Reloaded soundfont for audio recovery");
+				}
+				return ok;
+			},
+			getReapplyPlaybackAudioState: () =>
+				refreshAudioDepsRef.current.reapplyPlaybackAudioState,
+			isPlaybackStalled: async () => {
+				const api = apiRef.current;
+				if (!api) return false;
+				if (!useAppStore.getState().playerIsPlaying) return false;
+				const before = useAppStore.getState().playbackPositionTick;
+				await new Promise((resolve) => window.setTimeout(resolve, 1200));
+				if (apiRef.current !== api) return false;
+				const after = useAppStore.getState().playbackPositionTick;
+				return after <= before;
+			},
+		});
+	}
+	const refreshPlaybackAudioPipeline = playbackAudioRefreshRef.current.refresh;
 
-			if (shouldReloadSoundFont && currentSoundFontUrlRef.current) {
-				await loadSoundFontFromUrl(api, currentSoundFontUrlRef.current);
-				if (apiRef.current !== api) return;
-				await recoverPlaybackAudio();
-				if (apiRef.current !== api) return;
-				console.info(
-					`[Preview] Reloaded soundfont for audio recovery (${reason})`,
-				);
+	const showAudioStalledNotice = useCallback(() => {
+		const alreadyShownAt = useAppStore.getState().audioStalledNoticeAt;
+		if (alreadyShownAt !== null && Date.now() - alreadyShownAt < 60_000) {
+			return;
+		}
+		useAppStore.getState().setAudioStalledNoticeAt(Date.now());
+	}, []);
+
+	const handleAudioRecoveryResult = useCallback(
+		(
+			result: Awaited<ReturnType<PlaybackAudioRefreshCoordinator["refresh"]>>,
+		) => {
+			if (result.audioStalled) {
+				console.warn("[Preview] Playback stalled after audio recovery");
+				showAudioStalledNotice();
 			}
-
-			reapplyPlaybackAudioState(api);
-			lastPlaybackActivityAtRef.current = Date.now();
 		},
-		[recoverPlaybackAudio, reapplyPlaybackAudioState],
+		[showAudioStalledNotice],
 	);
 
 	useEffect(() => {
 		const handleWindowFocus = () => {
-			void refreshPlaybackAudioPipeline("window-focus");
+			void refreshPlaybackAudioPipeline("window-focus").then(
+				handleAudioRecoveryResult,
+			);
 		};
 		const handleVisibilityChange = () => {
 			if (!document.hidden) {
-				void refreshPlaybackAudioPipeline("visibility-return");
+				void refreshPlaybackAudioPipeline("visibility-return").then(
+					handleAudioRecoveryResult,
+				);
 			}
 		};
 
@@ -825,7 +862,7 @@ export default function Preview({
 			window.removeEventListener("focus", handleWindowFocus);
 			document.removeEventListener("visibilitychange", handleVisibilityChange);
 		};
-	}, [refreshPlaybackAudioPipeline]);
+	}, [refreshPlaybackAudioPipeline, handleAudioRecoveryResult]);
 
 	useEffect(() => {
 		metronomeOnlyModeRef.current = metronomeOnlyMode;
@@ -1484,6 +1521,29 @@ export default function Preview({
 								console.info(
 									`[Preview] api.play() invoked ${JSON.stringify({ didPlay, isReadyForPlayback: api.isReadyForPlayback, tickPosition: api.tickPosition })}`,
 								);
+
+								// 自愈验证：播放已启动但 tick 未推进说明 webview 音频输出失效
+								// （典型场景：显示器/系统睡眠后）。先走级联恢复，仍卡死则提示重启。
+								if (didPlay && apiRef.current === api) {
+									const startTick = useAppStore.getState().playbackPositionTick;
+									await new Promise((resolve) =>
+										window.setTimeout(resolve, 2000),
+									);
+									if (
+										apiRef.current === api &&
+										useAppStore.getState().playerIsPlaying &&
+										useAppStore.getState().playbackPositionTick <= startTick
+									) {
+										console.warn(
+											"[Preview] Playback started but tick is not advancing",
+										);
+										const result =
+											await refreshPlaybackAudioPipeline("play-stall");
+										if (apiRef.current === api) {
+											handleAudioRecoveryResult(result);
+										}
+									}
+								}
 							};
 
 							useAppStore.getState().clearScoreSelection();
@@ -1548,7 +1608,6 @@ export default function Preview({
 						api.pause?.();
 					},
 					stop: () => {
-						lastPlaybackActivityAtRef.current = Date.now();
 						countInPendingRef.current = false;
 						// 1. 停止播放器
 						api.stop?.();
@@ -1592,7 +1651,6 @@ export default function Preview({
 						}
 					},
 					refresh: () => {
-						lastPlaybackActivityAtRef.current = Date.now();
 						countInPendingRef.current = false;
 						bumpEditorRefreshVersion();
 						bumpBottomBarRefreshVersion();
@@ -2094,6 +2152,7 @@ export default function Preview({
 		setPlayerCursorIfChanged,
 		setPlayerIsPlayingIfChanged,
 		refreshPlaybackAudioPipeline,
+		handleAudioRecoveryResult,
 		resourceAssetOverrides,
 	]);
 

--- a/src/renderer/i18n/index.ts
+++ b/src/renderer/i18n/index.ts
@@ -3,6 +3,7 @@ import moment from "moment";
 import { initReactI18next } from "react-i18next";
 import "moment/locale/zh-cn";
 
+import enAudio from "./locales/en/audio.json";
 import enCommon from "./locales/en/common.json";
 import enErrors from "./locales/en/errors.json";
 import enPrint from "./locales/en/print.json";
@@ -11,6 +12,7 @@ import enSidebar from "./locales/en/sidebar.json";
 import enToolbar from "./locales/en/toolbar.json";
 import enUpdates from "./locales/en/updates.json";
 
+import zhCnAudio from "./locales/zh-cn/audio.json";
 import zhCnCommon from "./locales/zh-cn/common.json";
 import zhCnErrors from "./locales/zh-cn/errors.json";
 import zhCnPrint from "./locales/zh-cn/print.json";
@@ -28,6 +30,7 @@ const resources = {
 		print: enPrint,
 		errors: enErrors,
 		updates: enUpdates,
+		audio: enAudio,
 	},
 	"zh-cn": {
 		common: zhCnCommon,
@@ -37,6 +40,7 @@ const resources = {
 		print: zhCnPrint,
 		errors: zhCnErrors,
 		updates: zhCnUpdates,
+		audio: zhCnAudio,
 	},
 };
 

--- a/src/renderer/i18n/locales/en/audio.json
+++ b/src/renderer/i18n/locales/en/audio.json
@@ -1,0 +1,8 @@
+{
+	"recoveryToast": {
+		"title": "Audio output unavailable",
+		"message": "After system sleep the WebView audio output may stop working and reloading the soundfont did not recover it. Restarting the app restores playback.",
+		"restart": "Restart App",
+		"dismiss": "Got it"
+	}
+}

--- a/src/renderer/i18n/locales/zh-cn/audio.json
+++ b/src/renderer/i18n/locales/zh-cn/audio.json
@@ -1,0 +1,8 @@
+{
+	"recoveryToast": {
+		"title": "音频输出异常",
+		"message": "系统睡眠后 WKWebView 的音频输出可能失效，重载声音未能恢复。重启应用可恢复播放。",
+		"restart": "重启应用",
+		"dismiss": "知道了"
+	}
+}

--- a/src/renderer/lib/alphatab-config.ts
+++ b/src/renderer/lib/alphatab-config.ts
@@ -124,8 +124,6 @@ export function createPreviewSettings(
 		player: {
 			playerMode: alphaTab.PlayerMode.EnabledAutomatic,
 			enablePlayer: enablePlayerSafely,
-			outputMode: alphaTab.PlayerOutputMode.WebAudioScriptProcessor,
-			soundFont: urls.soundFontUrl,
 			...(scrollElement && {
 				scrollMode: alphaTab.ScrollMode.OffScreen,
 				scrollElement,

--- a/src/renderer/lib/assets.ts
+++ b/src/renderer/lib/assets.ts
@@ -95,9 +95,14 @@ export async function loadBravuraFont(fontUrl: string): Promise<boolean> {
 	}
 }
 
+const soundFontLoadsInFlight = new Map<string, Promise<boolean>>();
+
 /**
  * 通过 URL 加载音频到 alphaTab
  * 适用于已经通过 ResourceLoaderService 生成的音频 URL
+ *
+ * 并发调用同一 URL 时复用同一个加载任务；字体以替换（非追加）方式加载，
+ * 避免 focus/visibility 并发恢复或重复恢复导致相同 SoundFont 被重复 append。
  */
 export async function loadSoundFontFromUrl(
 	api: alphaTab.AlphaTabApi | null,
@@ -108,6 +113,24 @@ export async function loadSoundFontFromUrl(
 		return false;
 	}
 
+	const inFlight = soundFontLoadsInFlight.get(soundFontUrl);
+	if (inFlight) {
+		return inFlight;
+	}
+
+	const task = loadSoundFontFromUrlInner(api, soundFontUrl);
+	soundFontLoadsInFlight.set(soundFontUrl, task);
+	try {
+		return await task;
+	} finally {
+		soundFontLoadsInFlight.delete(soundFontUrl);
+	}
+}
+
+async function loadSoundFontFromUrlInner(
+	api: alphaTab.AlphaTabApi,
+	soundFontUrl: string,
+): Promise<boolean> {
 	try {
 		if (!isDesktopShellRuntime() && !hasUserActivatedAudio()) {
 			console.info(
@@ -144,7 +167,7 @@ export async function loadSoundFontFromUrl(
 		}
 
 		try {
-			api.loadSoundFont?.(u8, true);
+			api.loadSoundFont?.(u8, false);
 		} catch (error) {
 			console.warn("[AssetLoader] alphaTab rejected soundfont payload:", error);
 			return false;

--- a/src/renderer/lib/desktop-api.ts
+++ b/src/renderer/lib/desktop-api.ts
@@ -592,6 +592,11 @@ export function createWebDesktopAPI(): DesktopAPI {
 			success: false,
 			error: "keep-awake-unsupported",
 		}),
+
+		restartApp: async () => ({
+			success: false,
+			error: "Unsupported in web runtime",
+		}),
 	};
 
 	return api;

--- a/src/renderer/lib/player-audio-recovery.test.ts
+++ b/src/renderer/lib/player-audio-recovery.test.ts
@@ -88,7 +88,7 @@ describe("prepareAlphaTabAudioForPlayback", () => {
 		expect(result.finalState).toBe("running");
 	});
 
-	it("still activates running audio output to refresh playback path", async () => {
+	it("does not activate a running audio output", async () => {
 		const activate = vi.fn();
 		const result = await prepareAlphaTabAudioForPlayback({
 			player: {
@@ -101,8 +101,27 @@ describe("prepareAlphaTabAudioForPlayback", () => {
 			},
 		});
 
-		expect(activate).toHaveBeenCalledTimes(1);
+		expect(activate).not.toHaveBeenCalled();
+		expect(result.didAttemptActivation).toBe(false);
 		expect(result.finalState).toBe("running");
+	});
+
+	it("reports a closed context as unrecoverable without activating", async () => {
+		const activate = vi.fn();
+		const result = await prepareAlphaTabAudioForPlayback({
+			player: {
+				output: {
+					context: {
+						state: "closed",
+					},
+					activate,
+				},
+			},
+		});
+
+		expect(activate).not.toHaveBeenCalled();
+		expect(result.didAttemptActivation).toBe(false);
+		expect(result.finalState).toBe("closed");
 	});
 
 	it("safely no-ops when no player output is available", async () => {

--- a/src/renderer/lib/player-audio-recovery.ts
+++ b/src/renderer/lib/player-audio-recovery.ts
@@ -67,10 +67,6 @@ export function primeAlphaTabAudioOnUserGesture(
 	return didAttemptActivation;
 }
 
-function isRecoverableAudioState(state: string | undefined): boolean {
-	return state === "suspended" || state === "interrupted";
-}
-
 async function tryActivateOutput(
 	output: RecoverableAudioOutputLike,
 ): Promise<boolean> {
@@ -129,32 +125,44 @@ export async function prepareAlphaTabAudioForPlayback(
 	}
 
 	const initialState = output.context?.state ?? null;
-	let didAttemptActivation = false;
 
-	if (isRecoverableAudioState(output.context?.state)) {
-		didAttemptActivation =
-			(await tryActivateOutput(output)) || didAttemptActivation;
-		didAttemptActivation =
-			(await tryResumeContext(output.context)) || didAttemptActivation;
+	// Already running: alphaTab's activate() only invokes the callback after
+	// resuming a suspended/interrupted context, so calling it here would just
+	// burn the fallback timeout for no effect.
+	if (initialState === "running") {
+		return {
+			didAttemptActivation: false,
+			initialState,
+			finalState: "running",
+		};
+	}
 
-		if (isRecoverableAudioState(output.context?.state)) {
-			didAttemptActivation =
-				(await tryActivateOutput(output)) || didAttemptActivation;
-			didAttemptActivation =
-				(await tryResumeContext(output.context)) || didAttemptActivation;
-		}
-	} else {
-		didAttemptActivation =
-			(await tryActivateOutput(output)) || didAttemptActivation;
+	// Missing context, suspended or interrupted: try to activate (this creates
+	// the context and resumes it). Fall back to a direct resume when
+	// activation is unavailable or did not transition to running.
+	if (
+		initialState === null ||
+		initialState === "suspended" ||
+		initialState === "interrupted"
+	) {
+		let didAttemptActivation = await tryActivateOutput(output);
 		if (output.context?.state !== "running") {
 			didAttemptActivation =
 				(await tryResumeContext(output.context)) || didAttemptActivation;
 		}
+
+		return {
+			didAttemptActivation,
+			initialState,
+			finalState: output.context?.state ?? null,
+		};
 	}
 
+	// closed (or any other terminal state): cannot be recovered in place.
+	// Report it as-is so the caller can rebuild the soundfont/player.
 	return {
-		didAttemptActivation,
+		didAttemptActivation: false,
 		initialState,
-		finalState: output.context?.state ?? null,
+		finalState: initialState,
 	};
 }

--- a/src/renderer/lib/preview-audio-refresh.test.ts
+++ b/src/renderer/lib/preview-audio-refresh.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AudioRecoveryResult } from "./player-audio-recovery";
+import { createPlaybackAudioRefreshCoordinator } from "./preview-audio-refresh";
+
+function createCoordinator({
+	recovery,
+	reloadOk = true,
+	stalled = false,
+	stillStalled,
+}: {
+	recovery: AudioRecoveryResult;
+	reloadOk?: boolean;
+	stalled?: boolean;
+	stillStalled?: boolean;
+}) {
+	const api = { player: { output: { context: { state: "running" } } } };
+	const recover = vi.fn(async () => recovery);
+	const reloadSoundFont = vi.fn(async () => reloadOk);
+	const reapplyPlaybackAudioState = vi.fn();
+	let stallCalls = 0;
+	const isPlaybackStalled = vi.fn(async () => {
+		stallCalls += 1;
+		if (stallCalls === 1) return stalled;
+		return stillStalled === undefined ? stalled : stillStalled;
+	});
+	const depsRef = { recover, reapplyPlaybackAudioState };
+
+	const coordinator = createPlaybackAudioRefreshCoordinator({
+		getApi: () => api,
+		getRecoverPlaybackAudio: () => depsRef.recover,
+		reloadSoundFont,
+		getReapplyPlaybackAudioState: () => depsRef.reapplyPlaybackAudioState,
+		isPlaybackStalled,
+	});
+
+	return {
+		coordinator,
+		recover,
+		reloadSoundFont,
+		reapplyPlaybackAudioState,
+		isPlaybackStalled,
+	};
+}
+
+describe("createPlaybackAudioRefreshCoordinator", () => {
+	it("runs a single recovery when focus and visibilitychange fire together", async () => {
+		const { coordinator, recover, reapplyPlaybackAudioState } =
+			createCoordinator({
+				recovery: {
+					didAttemptActivation: false,
+					initialState: "running",
+					finalState: "running",
+				},
+			});
+
+		await Promise.all([
+			coordinator.refresh("window-focus"),
+			coordinator.refresh("visibility-return"),
+		]);
+
+		expect(recover).toHaveBeenCalledTimes(1);
+		expect(reapplyPlaybackAudioState).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not reload the soundfont when the context is running and playback advances", async () => {
+		const { coordinator, recover, reloadSoundFont } = createCoordinator({
+			recovery: {
+				didAttemptActivation: false,
+				initialState: "running",
+				finalState: "running",
+			},
+		});
+
+		const result = await coordinator.refresh("window-focus");
+
+		expect(reloadSoundFont).not.toHaveBeenCalled();
+		expect(recover).toHaveBeenCalledTimes(1);
+		expect(result.audioStalled).toBe(false);
+	});
+
+	it("reloads the soundfont when the context is closed", async () => {
+		const { coordinator, reloadSoundFont, recover } = createCoordinator({
+			recovery: {
+				didAttemptActivation: false,
+				initialState: "closed",
+				finalState: "closed",
+			},
+		});
+
+		await coordinator.refresh("window-focus");
+
+		expect(reloadSoundFont).toHaveBeenCalledTimes(1);
+		expect(recover).toHaveBeenCalledTimes(2);
+	});
+
+	it("reloads the soundfont when activation did not end in running state", async () => {
+		const { coordinator, reloadSoundFont } = createCoordinator({
+			recovery: {
+				didAttemptActivation: true,
+				initialState: "suspended",
+				finalState: "suspended",
+			},
+		});
+
+		await coordinator.refresh("window-focus");
+
+		expect(reloadSoundFont).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not reload the soundfont after a successful resume", async () => {
+		const { coordinator, reloadSoundFont } = createCoordinator({
+			recovery: {
+				didAttemptActivation: true,
+				initialState: "suspended",
+				finalState: "running",
+			},
+		});
+
+		await coordinator.refresh("window-focus");
+
+		expect(reloadSoundFont).not.toHaveBeenCalled();
+	});
+
+	it("reloads the soundfont when playback is stalled while running", async () => {
+		const { coordinator, reloadSoundFont, isPlaybackStalled } =
+			createCoordinator({
+				recovery: {
+					didAttemptActivation: false,
+					initialState: "running",
+					finalState: "running",
+				},
+				stalled: true,
+				stillStalled: false,
+			});
+
+		const result = await coordinator.refresh("window-focus");
+
+		expect(reloadSoundFont).toHaveBeenCalledTimes(1);
+		expect(isPlaybackStalled).toHaveBeenCalled();
+		expect(result.audioStalled).toBe(false);
+	});
+
+	it("reports audioStalled when playback is still stalled after the reload", async () => {
+		const { coordinator, reloadSoundFont } = createCoordinator({
+			recovery: {
+				didAttemptActivation: false,
+				initialState: "running",
+				finalState: "running",
+			},
+			stalled: true,
+			stillStalled: true,
+		});
+
+		const result = await coordinator.refresh("window-focus");
+
+		expect(reloadSoundFont).toHaveBeenCalledTimes(1);
+		expect(result.audioStalled).toBe(true);
+	});
+
+	it("does not reload when playback is not stalled", async () => {
+		const { coordinator, reloadSoundFont } = createCoordinator({
+			recovery: {
+				didAttemptActivation: false,
+				initialState: "running",
+				finalState: "running",
+			},
+		});
+
+		await coordinator.refresh("window-focus");
+
+		expect(reloadSoundFont).not.toHaveBeenCalled();
+	});
+
+	it("reapplies playback state after a recovery", async () => {
+		const { coordinator, reapplyPlaybackAudioState } = createCoordinator({
+			recovery: {
+				didAttemptActivation: false,
+				initialState: "running",
+				finalState: "running",
+			},
+		});
+
+		await coordinator.refresh("window-focus");
+
+		expect(reapplyPlaybackAudioState).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/renderer/lib/preview-audio-refresh.ts
+++ b/src/renderer/lib/preview-audio-refresh.ts
@@ -1,0 +1,114 @@
+/**
+ * Playback audio refresh coordinator
+ *
+ * Single owner for "window came back / audio needs recovery" refreshes.
+ * Window focus and visibilitychange both funnel into one single-flight
+ * refresh so a single macOS window return cannot trigger concurrent
+ * recoveries or soundfont reloads.
+ *
+ * Recovery is cascading:
+ * 1. resume the AudioContext in place (window-unfocus scenarios),
+ * 2. reload the soundfont (cheap in-place attempt),
+ * 3. if playback is still stalled (tick not advancing while playing), report
+ *    `audioStalled` so the caller can surface a user-facing restart hint —
+ *    the WKWebView audio subsystem is process-level broken after macOS
+ *    display/system sleep and cannot be fixed from inside the page.
+ */
+
+import type { AudioRecoveryResult } from "./player-audio-recovery";
+
+export interface PlaybackAudioRefreshDependencies<TApi> {
+	getApi: () => TApi | null;
+	getRecoverPlaybackAudio: () => () => Promise<AudioRecoveryResult | null>;
+	reloadSoundFont: (api: TApi) => Promise<boolean>;
+	getReapplyPlaybackAudioState: () => (api: TApi) => void;
+	/** True while playback is running but the tick position is not advancing. */
+	isPlaybackStalled: () => Promise<boolean>;
+}
+
+export interface PlaybackAudioRefreshResult {
+	/** True when the soundfont was reloaded but playback is still stalled. */
+	audioStalled: boolean;
+}
+
+export interface PlaybackAudioRefreshCoordinator {
+	refresh: (reason: string) => Promise<PlaybackAudioRefreshResult>;
+}
+
+/**
+ * Create a coordinator that serializes audio pipeline refreshes.
+ *
+ * Concurrent refresh() calls share the in-flight run. The soundfont is only
+ * reloaded when the AudioContext state cannot be recovered in place
+ * (closed), an activation attempt did not end in the running state, or
+ * playback is stalled while playing. Idle time alone never triggers a reload.
+ */
+export function createPlaybackAudioRefreshCoordinator<TApi>(
+	deps: PlaybackAudioRefreshDependencies<TApi>,
+): PlaybackAudioRefreshCoordinator {
+	let inFlight: Promise<PlaybackAudioRefreshResult> | null = null;
+
+	const refresh = (reason: string): Promise<PlaybackAudioRefreshResult> => {
+		if (inFlight) {
+			return inFlight;
+		}
+
+		inFlight = run(reason).finally(() => {
+			inFlight = null;
+		});
+		return inFlight;
+	};
+
+	async function run(reason: string): Promise<PlaybackAudioRefreshResult> {
+		const api = deps.getApi();
+		if (!api) {
+			return { audioStalled: false };
+		}
+
+		const recovery = await deps.getRecoverPlaybackAudio()();
+		if (deps.getApi() !== api) {
+			return { audioStalled: false };
+		}
+
+		const finalState = recovery?.finalState ?? null;
+		const attemptedButNotRunning =
+			recovery?.didAttemptActivation === true && finalState !== "running";
+		let needsSoundFontReload =
+			finalState === "closed" || attemptedButNotRunning;
+
+		if (!needsSoundFontReload) {
+			needsSoundFontReload = await deps.isPlaybackStalled();
+			if (deps.getApi() !== api) {
+				return { audioStalled: false };
+			}
+		}
+
+		if (!needsSoundFontReload) {
+			deps.getReapplyPlaybackAudioState()(api);
+			return { audioStalled: false };
+		}
+
+		const reloaded = await deps.reloadSoundFont(api);
+		if (deps.getApi() !== api) {
+			return { audioStalled: false };
+		}
+		if (reloaded) {
+			console.info(`[audio-refresh] reloaded soundfont (${reason})`);
+			await deps.getRecoverPlaybackAudio()();
+			if (deps.getApi() !== api) {
+				return { audioStalled: false };
+			}
+		}
+
+		deps.getReapplyPlaybackAudioState()(api);
+
+		const stillStalled = await deps.isPlaybackStalled();
+		if (deps.getApi() !== api) {
+			return { audioStalled: false };
+		}
+
+		return { audioStalled: stillStalled };
+	}
+
+	return { refresh };
+}

--- a/src/renderer/lib/tauri-desktop-api.ts
+++ b/src/renderer/lib/tauri-desktop-api.ts
@@ -634,6 +634,16 @@ export function createTauriDesktopAPI(): DesktopAPI {
 				return { success: false, error: toErrorMessage(error) };
 			}
 		},
+
+		restartApp: async (): Promise<{ success: boolean; error?: string }> => {
+			try {
+				return await invokeCommand<{ success: boolean; error?: string }>(
+					"restart_app",
+				);
+			} catch (error) {
+				return { success: false, error: toErrorMessage(error) };
+			}
+		},
 	};
 
 	return api;

--- a/src/renderer/store/appStore.ts
+++ b/src/renderer/store/appStore.ts
@@ -688,6 +688,9 @@ interface AppState {
 	// 🆕 第一个谱表显示选项
 	firstStaffOptions: StaffDisplayOptions | null;
 
+	// 🆕 音频输出异常提示的时间戳（null 表示未提示）
+	audioStalledNoticeAt: number | null;
+
 	// 🆕 待处理的谱表选项切换
 	pendingStaffToggle: keyof StaffDisplayOptions | null;
 
@@ -806,6 +809,9 @@ interface AppState {
 
 	// 🆕 谱表选项操作
 	setFirstStaffOptions: (options: StaffDisplayOptions | null) => void;
+
+	// 🆕 设置音频输出异常提示时间戳（null 清除）
+	setAudioStalledNoticeAt: (shownAt: number | null) => void;
 	toggleFirstStaffOption: (key: keyof StaffDisplayOptions) => void;
 	requestStaffToggle: (key: keyof StaffDisplayOptions) => void;
 
@@ -2030,6 +2036,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 			gitActionError: null,
 		}),
 	firstStaffOptions: null,
+	audioStalledNoticeAt: null,
 	pendingStaffToggle: null,
 	activeTutorialId: "user-readme",
 	setActiveTutorialId: (id) => {
@@ -2667,6 +2674,11 @@ export const useAppStore = create<AppState>((set, get) => ({
 	// 🆕 设置第一个谱表选项
 	setFirstStaffOptions: (options) => {
 		set({ firstStaffOptions: options });
+	},
+
+	// 🆕 音频输出异常提示（睡眠后 webview 音频失效，需要用户重启应用）
+	setAudioStalledNoticeAt: (shownAt: number | null) => {
+		set({ audioStalledNoticeAt: shownAt });
 	},
 
 	// 🆕 切换第一个谱表选项

--- a/src/renderer/types/desktop.d.ts
+++ b/src/renderer/types/desktop.d.ts
@@ -195,6 +195,10 @@ export interface DesktopAPI {
 		success: boolean;
 		error?: string;
 	}>;
+	restartApp: () => Promise<{
+		success: boolean;
+		error?: string;
+	}>;
 }
 
 declare global {


### PR DESCRIPTION
## Summary

Fixes two related audio problems discovered during a peer diagnostic review plus a full live debugging session:

1. **Stutter on window focus return** — playback became audibly choppy when switching away from Tabst and back while playing.
2. **Silent playback after long inactivity** — after leaving the app idle (display/system sleep), clicking play produced no sound.

## How the two problems are related

The old code "fixed" the silence with a blanket rule: *idle for 2 minutes → reload the 31MB SoundFont*. That reload pauses playback and reparses the font, which is exactly what caused the focus-return stutter. The live diagnosis (see below) proved the old fix **never actually repaired the silence** — it only masked timing symptoms — so removing it (to fix the stutter) made the silent-playback regression visible again.

## Debugging journey (live, against the running dev instance)

All conclusions below were verified experimentally with the Tauri MCP bridge, `osascript` window switching, and `pmset displaysleepnow`, not inferred:

| Scenario | Result |
| --- | --- |
| Playback, unfocus 15s / 5min (Finder foreground) | Normal — recovery path works |
| Stop → idle 5min → return → play | Normal |
| **Display sleep 2min → wake → play** | **Silent**: `AudioContext.state="running"`, `play()` returns `true`, `isReadyForPlayback=true`, tick never advances |
| Silent state → page reload (fresh API + worklet) | Still silent |
| Silent state → switch back to ScriptProcessor (rebuild) | Still silent (so the worklet change is **not** the cause) |
| Silent state → kill WebContent process | WebView does not respawn; page hangs |
| **Full app restart (fresh WebView process)** | **Audio restored** |

Root cause: after macOS display/system sleep, the WKWebView audio subsystem dies at the process level while all JS-visible state looks healthy. Page-level repair (resume, soundfont reload, API rebuild, output-mode switch) cannot fix it; only a fresh WebView process can. Full details in `docs/dev/reports/WKWEBVIEW_AUDIO_SLEEP_DIAGNOSIS.md`.

## Changes

**Core recovery (commits 1–2)**
- `prepareAlphaTabAudioForPlayback`: `running` context returns immediately (no useless `activate()` + 150ms wait); suspended/interrupted get one activation; `closed` reported unrecoverable.
- New `createPlaybackAudioRefreshCoordinator`: focus + visibilitychange funnel into a single-flight refresh (one recovery per window return, previously two concurrent runs).
- Soundfont reload only when context is `closed`, activation failed, or **playback is stalled** (tick not advancing while playing). Idle time alone never reloads.
- Playback self-healing: after `play()`, tick must advance within 2s; stalled → cascade recovery.
- Soundfont loading: removed `player.soundFont` setting so `loadSoundFontFromUrl` is the single owner; `append=false` + per-URL in-flight dedup.

**User-facing recovery (commit 3)**
- Toast with a **Restart** button when playback is still stalled after the cascade (WKWebView audio loss after sleep is not fixable in-page).
- New `restart_app` Tauri command: spawns the current executable, exits after 400ms; workspace state restored via existing autosave/session recovery. Web runtime reports unsupported.

**Docs (commit 4)**
- Full diagnosis report + `PREVIEW_LIFECYCLE.md` sync (removed class-observer docs, updated restoration matrix, new audio recovery section).

## Verification

- `pnpm check` ✓, `pnpm test` (180 tests, incl. new stall/cascade cases) ✓, `pnpm build:web` ✓
- `cargo check` + `cargo test` (17) ✓
- `pnpm docs:check` ✓
- Manual: focus/unfocus normal, display-sleep stall detected with toast + restart button

## Notes for reviewers

- The restart button is intentionally **manual** — no automatic app restarts.
- The sleep-induced audio loss is a WebKit limitation; the toast is the honest, supported path.