### PR TITLE
refactor: remove dual file model - opened docs + fileMetaByPath (#140)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -21,6 +21,7 @@ import { useFileOperations } from "./hooks/useFileOperations";
 import { getAlphaTexHighlight } from "./lib/alphatex-highlight";
 import { createAlphaTexLSPClient } from "./lib/alphatex-lsp";
 import { restoreAppZoomFactor } from "./lib/app-zoom";
+import { collectFileNodes } from "./lib/file-tree-utils";
 import { bindGlobalShortcutListener } from "./lib/shortcut-manager";
 import { isTemplateCandidateName } from "./lib/template-utils";
 import { runUiCommand } from "./lib/ui-command-registry";
@@ -29,7 +30,7 @@ import {
 	type UiShellCommandId,
 } from "./lib/ui-shell-events";
 import { isWebsiteMobileLayout } from "./lib/website-layout";
-import { type FileItem, useAppStore } from "./store/appStore";
+import { useAppStore } from "./store/appStore";
 
 const QuickFileSwitcher = lazy(() => import("./components/QuickFileSwitcher"));
 const GlobalCommandPalette = lazy(
@@ -90,35 +91,40 @@ function App() {
 		[templateFilePaths],
 	);
 
+	const fileMetaByPath = useAppStore((s) => s.fileMetaByPath);
+	const fileTree = useAppStore((s) => s.fileTree);
+
 	const templateItems = useMemo<TemplatePickerItem[]>(() => {
-		return files
+		return collectFileNodes(fileTree)
 			.filter(
-				(file) =>
-					templatePathSet.has(normalizePath(file.path)) &&
-					isTemplateCandidateName(file.name),
+				(node) =>
+					templatePathSet.has(normalizePath(node.path)) &&
+					isTemplateCandidateName(node.name),
 			)
-			.map((file) => ({
-				path: file.path,
-				name: file.name,
-				title: file.metaTitle,
+			.map((node) => ({
+				path: node.path,
+				name: node.name,
+				title: fileMetaByPath[normalizePath(node.path)]?.metaTitle,
 			}))
 			.sort((left, right) => left.name.localeCompare(right.name));
-	}, [files, templatePathSet]);
+	}, [fileTree, fileMetaByPath, templatePathSet]);
 
 	const filesByNormalizedPath = useMemo(
 		() => new Map(files.map((file) => [normalizePath(file.path), file])),
 		[files],
 	);
 
-	const resolveFileContent = async (file: FileItem): Promise<string | null> => {
-		if (file.contentLoaded) return file.content;
+	const resolveTemplateFileContent = async (
+		templatePath: string,
+	): Promise<string | null> => {
+		const cached = filesByNormalizedPath.get(normalizePath(templatePath));
+		if (cached?.contentLoaded) return cached.content;
 		try {
-			const result = await window.desktopAPI.readFile(file.path);
+			const result = await window.desktopAPI.readFile(templatePath);
 			if (result.error) {
 				console.error("Failed to read template file:", result.error);
 				return null;
 			}
-			updateFileContent(file.id, result.content);
 			return result.content;
 		} catch (error) {
 			console.error("Failed to resolve file content:", error);
@@ -129,14 +135,12 @@ function App() {
 	const handleInsertTemplate = async (templatePath: string) => {
 		const activeFile = files.find((file) => file.id === activeFileId);
 		if (!activeFile) return;
-
-		const templateFile = filesByNormalizedPath.get(normalizePath(templatePath));
-		if (!templateFile) return;
-		if (!isTemplateCandidateName(templateFile.name)) return;
+		if (!isTemplateCandidateName(templatePath.split(/[\\/]/).pop() ?? ""))
+			return;
 
 		const [activeContent, templateContent] = await Promise.all([
-			resolveFileContent(activeFile),
-			resolveFileContent(templateFile),
+			resolveTemplateFileContent(activeFile.path),
+			resolveTemplateFileContent(templatePath),
 		]);
 		if (activeContent == null || templateContent == null) return;
 
@@ -170,14 +174,13 @@ function App() {
 	};
 
 	const handleCreateFromTemplate = async (templatePath: string) => {
-		const templateFile = filesByNormalizedPath.get(normalizePath(templatePath));
-		if (!templateFile) return;
-		if (!isTemplateCandidateName(templateFile.name)) return;
+		if (!isTemplateCandidateName(templatePath.split(/[\\/]/).pop() ?? ""))
+			return;
 
-		const templateContent = await resolveFileContent(templateFile);
+		const templateContent = await resolveTemplateFileContent(templatePath);
 		if (templateContent == null) return;
 
-		const templateExt: ".md" | ".atex" = templateFile.name
+		const templateExt: ".md" | ".atex" = templatePath
 			.toLowerCase()
 			.endsWith(".atex")
 			? ".atex"

--- a/src/renderer/components/FileTreeItem.tsx
+++ b/src/renderer/components/FileTreeItem.tsx
@@ -119,36 +119,29 @@ export function FileTreeItem({
 		useCallback(
 			(s) => {
 				if (isFolder) return EMPTY_TAGS;
-				const current = s.files.find(
-					(f) => f.id === node.id || f.path === node.path,
+				return (
+					s.fileMetaByPath[normalizePath(node.path)]?.metaTags ?? EMPTY_TAGS
 				);
-				return current?.metaTags ?? EMPTY_TAGS;
 			},
-			[isFolder, node.id, node.path],
+			[isFolder, node.path],
 		),
 	);
 	const fileMetaTitle = useAppStore(
 		useCallback(
 			(s) => {
 				if (isFolder) return undefined;
-				const current = s.files.find(
-					(f) => f.id === node.id || f.path === node.path,
-				);
-				return current?.metaTitle;
+				return s.fileMetaByPath[normalizePath(node.path)]?.metaTitle;
 			},
-			[isFolder, node.id, node.path],
+			[isFolder, node.path],
 		),
 	);
 	const fileMetaStatus = useAppStore(
 		useCallback(
 			(s) => {
 				if (isFolder) return undefined;
-				const current = s.files.find(
-					(f) => f.id === node.id || f.path === node.path,
-				);
-				return current?.metaStatus;
+				return s.fileMetaByPath[normalizePath(node.path)]?.metaStatus;
 			},
-			[isFolder, node.id, node.path],
+			[isFolder, node.path],
 		),
 	);
 	const isTemplateFile = useAppStore(

--- a/src/renderer/components/QuickFileSwitcher.tsx
+++ b/src/renderer/components/QuickFileSwitcher.tsx
@@ -1,8 +1,8 @@
 import { FileMusic, Hash } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { extractAtDocFileMeta } from "../lib/atdoc";
+import { collectFileNodes } from "../lib/file-tree-utils";
 import { useAppStore } from "../store/appStore";
-import type { FileNode } from "../types/repo";
 import { Dialog, DialogContent, DialogTitle } from "./ui/dialog";
 import { Input } from "./ui/input";
 
@@ -33,20 +33,6 @@ interface AtexCandidate {
 	metaRelease?: string;
 	metaAlias: string[];
 	metaTitle?: string;
-}
-
-function flattenFileNodes(nodes: FileNode[]): FileNode[] {
-	const out: FileNode[] = [];
-	for (const node of nodes) {
-		if (node.type === "file") {
-			out.push(node);
-			continue;
-		}
-		if (node.children?.length) {
-			out.push(...flattenFileNodes(node.children));
-		}
-	}
-	return out;
 }
 
 function normalizePath(path: string): string {
@@ -112,10 +98,11 @@ export default function QuickFileSwitcher({
 }: QuickFileSwitcherProps) {
 	const fileTree = useAppStore((s) => s.fileTree);
 	const openedFiles = useAppStore((s) => s.files);
+	const fileMetaByPath = useAppStore((s) => s.fileMetaByPath);
 	const addFile = useAppStore((s) => s.addFile);
 	const setActiveFile = useAppStore((s) => s.setActiveFile);
 	const setWorkspaceMode = useAppStore((s) => s.setWorkspaceMode);
-	const setFileMeta = useAppStore((s) => s.setFileMeta);
+	const setFileMetaByPath = useAppStore((s) => s.setFileMetaByPath);
 
 	const [query, setQuery] = useState("");
 	const [loading, setLoading] = useState(false);
@@ -125,7 +112,7 @@ export default function QuickFileSwitcher({
 	const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
 
 	const loadCandidates = useCallback(async () => {
-		const atexNodes = flattenFileNodes(fileTree).filter((node) =>
+		const atexNodes = collectFileNodes(fileTree).filter((node) =>
 			node.name.toLowerCase().endsWith(".atex"),
 		);
 
@@ -137,17 +124,18 @@ export default function QuickFileSwitcher({
 		for (const node of atexNodes) {
 			const normalizedPath = normalizePath(node.path);
 			const opened = byPath.get(normalizedPath);
-			let metaTags = [...(opened?.metaTags ?? [])];
-			let metaClass = [...(opened?.metaClass ?? [])];
-			let metaAlias = [...(opened?.metaAlias ?? [])];
-			let metaStatus = opened?.metaStatus;
-			let metaTabist = opened?.metaTabist;
-			let metaApp = opened?.metaApp;
-			let metaGithub = opened?.metaGithub;
-			let metaLicense = opened?.metaLicense;
-			let metaSource = opened?.metaSource;
-			let metaRelease = opened?.metaRelease;
-			let metaTitle = opened?.metaTitle;
+			const cachedMeta = fileMetaByPath[normalizedPath];
+			let metaTags = [...(cachedMeta?.metaTags ?? [])];
+			let metaClass = [...(cachedMeta?.metaClass ?? [])];
+			let metaAlias = [...(cachedMeta?.metaAlias ?? [])];
+			let metaStatus = cachedMeta?.metaStatus;
+			let metaTabist = cachedMeta?.metaTabist;
+			let metaApp = cachedMeta?.metaApp;
+			let metaGithub = cachedMeta?.metaGithub;
+			let metaLicense = cachedMeta?.metaLicense;
+			let metaSource = cachedMeta?.metaSource;
+			let metaRelease = cachedMeta?.metaRelease;
+			let metaTitle = cachedMeta?.metaTitle;
 
 			if (
 				metaTags.length === 0 &&
@@ -172,6 +160,21 @@ export default function QuickFileSwitcher({
 
 				if (typeof content === "string" && content.length > 0) {
 					const parsedMeta = extractAtDocFileMeta(content);
+					if (
+						!sameStringArray(cachedMeta?.metaClass, parsedMeta.metaClass) ||
+						!sameStringArray(cachedMeta?.metaTags, parsedMeta.metaTags) ||
+						cachedMeta?.metaStatus !== parsedMeta.metaStatus ||
+						cachedMeta?.metaTabist !== parsedMeta.metaTabist ||
+						cachedMeta?.metaApp !== parsedMeta.metaApp ||
+						cachedMeta?.metaGithub !== parsedMeta.metaGithub ||
+						cachedMeta?.metaLicense !== parsedMeta.metaLicense ||
+						cachedMeta?.metaSource !== parsedMeta.metaSource ||
+						cachedMeta?.metaRelease !== parsedMeta.metaRelease ||
+						!sameStringArray(cachedMeta?.metaAlias, parsedMeta.metaAlias) ||
+						cachedMeta?.metaTitle !== parsedMeta.metaTitle
+					) {
+						setFileMetaByPath(node.path, parsedMeta);
+					}
 					metaTags = parsedMeta.metaTags;
 					metaClass = parsedMeta.metaClass;
 					metaAlias = parsedMeta.metaAlias;
@@ -183,35 +186,6 @@ export default function QuickFileSwitcher({
 					metaSource = parsedMeta.metaSource;
 					metaRelease = parsedMeta.metaRelease;
 					metaTitle = parsedMeta.metaTitle;
-					if (
-						opened &&
-						(!sameStringArray(opened.metaClass, metaClass) ||
-							!sameStringArray(opened.metaTags, metaTags) ||
-							opened.metaStatus !== metaStatus ||
-							opened.metaTabist !== metaTabist ||
-							opened.metaApp !== metaApp ||
-							opened.metaGithub !== metaGithub ||
-							opened.metaLicense !== metaLicense ||
-							opened.metaSource !== metaSource ||
-							opened.metaRelease !== metaRelease ||
-							!sameStringArray(opened.metaAlias, metaAlias) ||
-							opened.metaTitle !== metaTitle)
-					) {
-						setFileMeta(
-							opened.id,
-							metaClass,
-							metaTags,
-							metaStatus,
-							metaTabist,
-							metaApp,
-							metaGithub,
-							metaLicense,
-							metaSource,
-							metaRelease,
-							metaAlias,
-							metaTitle,
-						);
-					}
 				}
 			}
 
@@ -235,7 +209,7 @@ export default function QuickFileSwitcher({
 
 		loaded.sort((a, b) => a.name.localeCompare(b.name));
 		setCandidates(loaded);
-	}, [fileTree, openedFiles, setFileMeta]);
+	}, [fileTree, openedFiles, fileMetaByPath, setFileMetaByPath]);
 
 	const loadCandidatesRef = useRef(loadCandidates);
 
@@ -333,17 +307,6 @@ export default function QuickFileSwitcher({
 							name: existing.name,
 							path: existing.path,
 							content: readResult.content,
-							metaClass: existing.metaClass,
-							metaTags: existing.metaTags,
-							metaAlias: existing.metaAlias,
-							metaStatus: existing.metaStatus,
-							metaTabist: existing.metaTabist,
-							metaApp: existing.metaApp,
-							metaGithub: existing.metaGithub,
-							metaLicense: existing.metaLicense,
-							metaSource: existing.metaSource,
-							metaRelease: existing.metaRelease,
-							metaTitle: existing.metaTitle,
 							contentLoaded: true,
 						});
 					}
@@ -362,17 +325,6 @@ export default function QuickFileSwitcher({
 				name: candidate.name,
 				path: candidate.path,
 				content: readResult.content,
-				metaClass: candidate.metaClass,
-				metaTags: candidate.metaTags,
-				metaAlias: candidate.metaAlias,
-				metaStatus: candidate.metaStatus,
-				metaTabist: candidate.metaTabist,
-				metaApp: candidate.metaApp,
-				metaGithub: candidate.metaGithub,
-				metaLicense: candidate.metaLicense,
-				metaSource: candidate.metaSource,
-				metaRelease: candidate.metaRelease,
-				metaTitle: candidate.metaTitle,
 				contentLoaded: true,
 			});
 			setActiveFile(candidate.path);

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -106,7 +106,7 @@ export function Sidebar({ onCollapse }: SidebarProps) {
 	const expandFolder = useAppStore((s) => s.expandFolder);
 	const collapseFolder = useAppStore((s) => s.collapseFolder);
 	const refreshFileTree = useAppStore((s) => s.refreshFileTree);
-	const files = useAppStore((s) => s.files);
+	const fileMetaByPath = useAppStore((s) => s.fileMetaByPath);
 	const addFile = useAppStore((s) => s.addFile);
 	const setFileMetaByPath = useAppStore((s) => s.setFileMetaByPath);
 	const renameFile = useAppStore((s) => s.renameFile);
@@ -348,28 +348,28 @@ export function Sidebar({ onCollapse }: SidebarProps) {
 
 	const tagsByPath = useMemo(() => {
 		const map = new Map<string, string[]>();
-		for (const file of files) {
-			map.set(normalizePath(file.path), file.metaTags ?? []);
+		for (const [path, meta] of Object.entries(fileMetaByPath)) {
+			map.set(path, meta.metaTags ?? []);
 		}
 		return map;
-	}, [files]);
+	}, [fileMetaByPath]);
 
 	const availableTags = useMemo(() => {
 		const set = new Set<string>();
-		for (const file of files) {
-			for (const tag of file.metaTags ?? []) {
+		for (const meta of Object.values(fileMetaByPath)) {
+			for (const tag of meta.metaTags ?? []) {
 				const cleaned = tag.trim();
 				if (cleaned) set.add(cleaned);
 			}
 		}
 		return Array.from(set).sort((a, b) => a.localeCompare(b));
-	}, [files]);
+	}, [fileMetaByPath]);
 
 	const availableStatuses = useMemo(() => {
 		const set = new Set<"draft" | "active" | "done" | "released">();
-		for (const file of files) {
-			if (file.metaStatus) {
-				set.add(file.metaStatus);
+		for (const meta of Object.values(fileMetaByPath)) {
+			if (meta.metaStatus) {
+				set.add(meta.metaStatus);
 			}
 		}
 		const order: Array<"draft" | "active" | "done" | "released"> = [
@@ -379,7 +379,7 @@ export function Sidebar({ onCollapse }: SidebarProps) {
 			"released",
 		];
 		return order.filter((status) => set.has(status));
-	}, [files]);
+	}, [fileMetaByPath]);
 
 	const sidebarVisibleTree = useMemo(
 		() => filterSidebarVisibleNodes(fileTree),
@@ -418,7 +418,12 @@ export function Sidebar({ onCollapse }: SidebarProps) {
 		const statusByPath = new Map<
 			string,
 			"draft" | "active" | "done" | "released" | undefined
-		>(files.map((file) => [normalizePath(file.path), file.metaStatus]));
+		>(
+			Object.entries(fileMetaByPath).map(([path, meta]) => [
+				path,
+				meta.metaStatus,
+			]),
+		);
 
 		const filterNodes = (nodes: FileNode[]): FileNode[] => {
 			const out: FileNode[] = [];
@@ -449,38 +454,35 @@ export function Sidebar({ onCollapse }: SidebarProps) {
 		return filterNodes(sidebarVisibleTree);
 	}, [
 		sidebarVisibleTree,
-		files,
 		selectedStatusFilters,
 		selectedTagFilters,
 		tagsByPath,
+		fileMetaByPath,
 	]);
 
 	useEffect(() => {
 		if (workspaceMode !== "editor" || !activeRepoId) return;
 
-		const openedByPath = new Map(
-			files.map((file) => [normalizePath(file.path), file]),
-		);
 		const atexNodes = flattenNodes(fileTree).filter((node) =>
 			node.name.toLowerCase().endsWith(".atex"),
 		);
 		const pendingPaths = atexNodes
 			.map((node) => normalizePath(node.path))
 			.filter((path) => {
-				const file = openedByPath.get(path);
+				const meta = fileMetaByPath[path];
 				return (
-					!file ||
-					(!file.metaClass &&
-						!file.metaTags &&
-						!file.metaStatus &&
-						!file.metaTabist &&
-						!file.metaApp &&
-						!file.metaGithub &&
-						!file.metaLicense &&
-						!file.metaSource &&
-						!file.metaRelease &&
-						!file.metaAlias &&
-						!file.metaTitle)
+					!meta ||
+					(!meta.metaClass &&
+						!meta.metaTags &&
+						!meta.metaStatus &&
+						!meta.metaTabist &&
+						!meta.metaApp &&
+						!meta.metaGithub &&
+						!meta.metaLicense &&
+						!meta.metaSource &&
+						!meta.metaRelease &&
+						!meta.metaAlias &&
+						!meta.metaTitle)
 				);
 			});
 
@@ -494,20 +496,7 @@ export function Sidebar({ onCollapse }: SidebarProps) {
 					const readResult = await window.desktopAPI.readFile(path);
 					if (readResult.error) continue;
 					const parsedMeta = extractAtDocFileMeta(readResult.content);
-					setFileMetaByPath(
-						path,
-						parsedMeta.metaClass,
-						parsedMeta.metaTags,
-						parsedMeta.metaStatus,
-						parsedMeta.metaTabist,
-						parsedMeta.metaApp,
-						parsedMeta.metaGithub,
-						parsedMeta.metaLicense,
-						parsedMeta.metaSource,
-						parsedMeta.metaRelease,
-						parsedMeta.metaAlias,
-						parsedMeta.metaTitle,
-					);
+					setFileMetaByPath(path, parsedMeta);
 				} catch {}
 			}
 		})();
@@ -515,7 +504,13 @@ export function Sidebar({ onCollapse }: SidebarProps) {
 		return () => {
 			cancelled = true;
 		};
-	}, [activeRepoId, fileTree, files, setFileMetaByPath, workspaceMode]);
+	}, [
+		activeRepoId,
+		fileTree,
+		fileMetaByPath,
+		setFileMetaByPath,
+		workspaceMode,
+	]);
 
 	const getParentDirectory = (p: string): string | undefined => {
 		const normalized = normalizePath(p);

--- a/src/renderer/components/settings/TemplatesPage.tsx
+++ b/src/renderer/components/settings/TemplatesPage.tsx
@@ -1,6 +1,7 @@
 import { Sparkles } from "lucide-react";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import { collectFileNodes } from "../../lib/file-tree-utils";
 import {
 	isTemplateCandidateName,
 	normalizeTemplatePath,
@@ -13,6 +14,7 @@ import { CheckboxToggle } from "../ui/checkbox-toggle";
 export function TemplatesPage() {
 	const { t } = useTranslation("settings");
 	const files = useAppStore((s) => s.files);
+	const fileTree = useAppStore((s) => s.fileTree);
 	const activeFileId = useAppStore((s) => s.activeFileId);
 	const templateFilePaths = useAppStore((s) => s.templateFilePaths);
 	const setFileTemplate = useAppStore((s) => s.setFileTemplate);
@@ -28,8 +30,11 @@ export function TemplatesPage() {
 	);
 
 	const candidateFiles = useMemo(
-		() => files.filter((file) => isTemplateCandidateName(file.name)),
-		[files],
+		() =>
+			collectFileNodes(fileTree)
+				.filter((node) => isTemplateCandidateName(node.name))
+				.map((node) => ({ path: node.path, name: node.name })),
+		[fileTree],
 	);
 
 	const activeFileSupportsTemplate =

--- a/src/renderer/lib/file-tree-utils.ts
+++ b/src/renderer/lib/file-tree-utils.ts
@@ -1,0 +1,30 @@
+import type { FileNode } from "../types/repo";
+
+/**
+ * 遍历文件树，收集所有文件节点（保留树的展开顺序）。
+ */
+export function collectFileNodes(nodes: FileNode[]): FileNode[] {
+	const result: FileNode[] = [];
+	for (const node of nodes) {
+		if (node.type === "file") {
+			result.push(node);
+		} else if (node.children) {
+			result.push(...collectFileNodes(node.children));
+		}
+	}
+	return result;
+}
+
+/**
+ * 收集树中所有文件节点的 normalized path 集合。
+ */
+export function collectFilePaths(
+	nodes: FileNode[],
+	normalize: (p: string) => string,
+): Set<string> {
+	const result = new Set<string>();
+	for (const node of collectFileNodes(nodes)) {
+		result.add(normalize(node.path));
+	}
+	return result;
+}

--- a/src/renderer/store/appStore.fileMeta.test.ts
+++ b/src/renderer/store/appStore.fileMeta.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => {
+	const desktopApi = {
+		loadGlobalSettings: vi.fn(async () => ({ success: true, data: {} })),
+		saveGlobalSettings: vi.fn(async () => ({ success: true })),
+		saveFile: vi.fn(async () => ({ success: true })),
+		readFile: vi.fn(async () => ({ content: "", error: null })),
+		renameFile: vi.fn(),
+		loadExternalSoundFontSettings: vi.fn(async () => ({
+			success: true,
+			configured: false,
+			valid: false,
+		})),
+	};
+	return { desktopApi };
+});
+
+const { useAppStore } = await import("./appStore");
+
+const BASE_CONTENT = `at.meta.title="Test"`;
+
+describe("fileMetaByPath", () => {
+	beforeEach(() => {
+		vi.stubGlobal("window", {
+			desktopAPI: hoisted.desktopApi,
+			setTimeout: (callback: () => void) => setTimeout(callback, 0),
+			clearTimeout,
+		});
+		useAppStore.setState({
+			files: [],
+			fileMetaByPath: {},
+			activeFileId: null,
+			repos: [],
+			activeRepoId: null,
+			fileTree: [],
+		});
+		vi.clearAllMocks();
+	});
+
+	it("parses ATDOC meta from addFile content into fileMetaByPath", () => {
+		const content = `${BASE_CONTENT}\nat.meta.class="lesson"\nat.meta.tag="guitar"`;
+		const store = useAppStore.getState();
+		store.addFile({
+			id: "/repo/song.atex",
+			name: "song.atex",
+			path: "/repo/song.atex",
+			content,
+			contentLoaded: true,
+		});
+
+		const meta = useAppStore.getState().fileMetaByPath["/repo/song.atex"];
+		expect(meta.metaClass).toEqual(["lesson"]);
+		expect(meta.metaTags).toEqual(["guitar"]);
+		expect(meta.metaTitle).toBe("Test");
+	});
+
+	it("updates fileMetaByPath when content changes", () => {
+		const store = useAppStore.getState();
+		store.addFile({
+			id: "/repo/song.atex",
+			name: "song.atex",
+			path: "/repo/song.atex",
+			content: BASE_CONTENT,
+			contentLoaded: true,
+		});
+		store.updateFileContent(
+			"/repo/song.atex",
+			`${BASE_CONTENT}\nat.meta.tag="arrangement"`,
+		);
+
+		const meta = useAppStore.getState().fileMetaByPath["/repo/song.atex"];
+		expect(meta.metaTags).toEqual(["arrangement"]);
+		expect(meta.metaClass).toBeUndefined();
+	});
+
+	it("merges partial meta from setFileMetaByPath", () => {
+		const store = useAppStore.getState();
+		store.setFileMetaByPath("/repo/song.atex", {
+			metaTags: ["guitar"],
+			metaStatus: "active",
+		});
+		store.setFileMetaByPath("/repo/song.atex", {
+			metaTitle: "My Title",
+		});
+
+		const meta = useAppStore.getState().fileMetaByPath["/repo/song.atex"];
+		expect(meta.metaTags).toEqual(["guitar"]);
+		expect(meta.metaStatus).toBe("active");
+		expect(meta.metaTitle).toBe("My Title");
+	});
+
+	it("removes fileMetaByPath when the opened file is removed", () => {
+		const store = useAppStore.getState();
+		store.addFile({
+			id: "/repo/song.atex",
+			name: "song.atex",
+			path: "/repo/song.atex",
+			content: BASE_CONTENT,
+			contentLoaded: true,
+		});
+		expect(
+			useAppStore.getState().fileMetaByPath["/repo/song.atex"],
+		).toBeDefined();
+
+		store.removeFile("/repo/song.atex");
+		expect(
+			useAppStore.getState().fileMetaByPath["/repo/song.atex"],
+		).toBeUndefined();
+	});
+
+	it("keeps opened files independent of a tree refresh", async () => {
+		hoisted.desktopApi.scanDirectory = vi.fn(async () => ({
+			nodes: [
+				{
+					id: "/repo/other.atex",
+					name: "other.atex",
+					path: "/repo/other.atex",
+					type: "file",
+				},
+			],
+			expandedFolders: [],
+		}));
+		const store = useAppStore.getState();
+		store.addFile({
+			id: "/repo/song.atex",
+			name: "song.atex",
+			path: "/repo/song.atex",
+			content: BASE_CONTENT,
+			contentLoaded: true,
+		});
+		useAppStore.setState({
+			activeRepoId: "repo-1",
+			repos: [{ id: "repo-1", path: "/repo", name: "repo" }],
+		});
+
+		await store.refreshFileTree();
+
+		const state = useAppStore.getState();
+		expect(state.files).toHaveLength(0);
+		expect(state.fileTree).toHaveLength(1);
+	});
+
+	it("migrates fileMetaByPath keys on rename", async () => {
+		hoisted.desktopApi.renameFile = vi.fn(async () => ({
+			success: true,
+			newPath: "/repo/renamed.atex",
+			newName: "renamed.atex",
+		}));
+		const store = useAppStore.getState();
+		store.addFile({
+			id: "/repo/song.atex",
+			name: "song.atex",
+			path: "/repo/song.atex",
+			content: `${BASE_CONTENT}\nat.meta.tag="guitar"`,
+			contentLoaded: true,
+		});
+		useAppStore.setState({
+			activeRepoId: "repo-1",
+			repos: [{ id: "repo-1", path: "/repo", name: "repo" }],
+		});
+
+		const renamed = await store.renameFile("/repo/song.atex", "renamed");
+		expect(renamed).toBe(true);
+
+		const state = useAppStore.getState();
+		expect(state.fileMetaByPath["/repo/song.atex"]).toBeUndefined();
+		expect(state.fileMetaByPath["/repo/renamed.atex"]?.metaTags).toEqual([
+			"guitar",
+		]);
+	});
+});

--- a/src/renderer/store/appStore.ts
+++ b/src/renderer/store/appStore.ts
@@ -4,6 +4,7 @@ import i18n, { type Locale } from "../i18n";
 import { setActiveRepoContext } from "../lib/active-repo-context";
 import { extractAtDocFileMeta } from "../lib/atdoc";
 import { listCloudPublicScoresWithContent } from "../lib/cloud-public-scores";
+import { collectFileNodes } from "../lib/file-tree-utils";
 import { loadGlobalSettings, saveGlobalSettings } from "../lib/global-settings";
 import {
 	BUILT_IN_FONT_OPTIONS,
@@ -31,6 +32,7 @@ import type {
 } from "../types/git";
 import type {
 	DeleteBehavior,
+	FileMeta,
 	FileNode,
 	Repo,
 	RepoPreferences,
@@ -179,13 +181,14 @@ async function createDefaultSandboxRepo(): Promise<Repo | null> {
 async function appendCloudPublicScoresToSandboxRepo(repo: Repo): Promise<void> {
 	try {
 		const scanResult = await window.desktopAPI.scanDirectory(repo.path);
-		const existingFiles = scanResult ? flattenFileNodes(scanResult.nodes) : [];
+		const existingFiles = scanResult ? collectFileNodes(scanResult.nodes) : [];
 		const existingFilesBySourceId = new Map(
 			existingFiles
 				.map(
-					(file) => [extractCloudPublicSourceId(file.content), file] as const,
+					(node) =>
+						[extractCloudPublicSourceId(node.content ?? ""), node] as const,
 				)
-				.filter((entry): entry is readonly [string, FileItem] =>
+				.filter((entry): entry is readonly [string, FileNode] =>
 					Boolean(entry[0]),
 				),
 		);
@@ -245,31 +248,14 @@ async function appendCloudPublicScoresToSandboxRepo(repo: Repo): Promise<void> {
 }
 
 /**
- * @deprecated 使用 FileNode 替代
+ * 已打开文档（标签页语义）：addFile/removeFile 维护。
+ * 元数据不再内嵌，统一存于 `fileMetaByPath`。
  */
 export interface FileItem {
 	id: string;
 	name: string;
 	path: string;
 	content: string;
-	metaClass?: string[];
-	metaTags?: string[];
-	metaStatus?: "draft" | "active" | "done" | "released";
-	metaTabist?: string;
-	metaApp?: string;
-	metaGithub?: string;
-	metaLicense?:
-		| "CC0-1.0"
-		| "CC-BY-4.0"
-		| "CC-BY-SA-4.0"
-		| "CC-BY-NC-4.0"
-		| "CC-BY-NC-SA-4.0"
-		| "CC-BY-ND-4.0"
-		| "CC-BY-NC-ND-4.0";
-	metaSource?: string;
-	metaRelease?: string;
-	metaAlias?: string[];
-	metaTitle?: string;
 	/** Whether `content` is hydrated from disk/user input (vs empty placeholder from file tree scan). */
 	contentLoaded?: boolean;
 }
@@ -552,8 +538,10 @@ interface AppState {
 	repos: Repo[];
 	activeRepoId: string | null;
 	fileTree: FileNode[];
-	// 保留 files 以兼容现有代码，实际使用 fileTree
+	// 已打开文档（标签页语义），由 addFile/removeFile 维护
 	files: FileItem[];
+	// 树节点 ATDOC 元数据缓存（key: normalized path）
+	fileMetaByPath: Record<string, FileMeta>;
 	// 用户偏好设置
 	deleteBehavior: DeleteBehavior;
 	setDeleteBehavior: (behavior: DeleteBehavior) => void;
@@ -573,6 +561,7 @@ interface AppState {
 
 	// 当前选中的文件
 	activeFileId: string | null;
+	openFileByPath: (path: string) => Promise<boolean>;
 
 	// 🆕 音轨面板显示状态
 	isTracksPanelOpen: boolean;
@@ -740,48 +729,7 @@ interface AppState {
 	renameFile: (id: string, newName: string) => Promise<boolean>;
 	setActiveFile: (id: string | null) => void;
 	updateFileContent: (id: string, content: string) => void;
-	setFileMeta: (
-		id: string,
-		metaClass: string[],
-		metaTags: string[],
-		metaStatus?: "draft" | "active" | "done" | "released",
-		metaTabist?: string,
-		metaApp?: string,
-		metaGithub?: string,
-		metaLicense?:
-			| "CC0-1.0"
-			| "CC-BY-4.0"
-			| "CC-BY-SA-4.0"
-			| "CC-BY-NC-4.0"
-			| "CC-BY-NC-SA-4.0"
-			| "CC-BY-ND-4.0"
-			| "CC-BY-NC-ND-4.0",
-		metaSource?: string,
-		metaRelease?: string,
-		metaAlias?: string[],
-		metaTitle?: string,
-	) => void;
-	setFileMetaByPath: (
-		path: string,
-		metaClass: string[],
-		metaTags: string[],
-		metaStatus?: "draft" | "active" | "done" | "released",
-		metaTabist?: string,
-		metaApp?: string,
-		metaGithub?: string,
-		metaLicense?:
-			| "CC0-1.0"
-			| "CC-BY-4.0"
-			| "CC-BY-SA-4.0"
-			| "CC-BY-NC-4.0"
-			| "CC-BY-NC-SA-4.0"
-			| "CC-BY-ND-4.0"
-			| "CC-BY-NC-ND-4.0",
-		metaSource?: string,
-		metaRelease?: string,
-		metaAlias?: string[],
-		metaTitle?: string,
-	) => void;
+	setFileMetaByPath: (path: string, meta: FileMeta) => void;
 	getActiveFile: () => FileItem | undefined;
 
 	// 🆕 选区操作
@@ -1129,7 +1077,8 @@ export const useAppStore = create<AppState>((set, get) => ({
 						repos: newRepos,
 						activeRepoId: id,
 						fileTree: result.nodes,
-						files: flattenFileNodes(result.nodes),
+						files: [],
+						fileMetaByPath: {},
 						templateFilePaths: [],
 						commandShortcuts: {},
 						activeFileId: null,
@@ -1335,41 +1284,12 @@ export const useAppStore = create<AppState>((set, get) => ({
 						});
 
 						if (meta.activeFilePath) {
-							const normalizedPath = normalizePathForCompare(
-								meta.activeFilePath,
-							);
-							const targetFile = get().files.find(
-								(file) => normalizePathForCompare(file.path) === normalizedPath,
-							);
-
-							if (targetFile) {
-								if (!targetFile.contentLoaded) {
-									try {
-										const readResult = await window.desktopAPI.readFile(
-											targetFile.path,
-										);
-										if (!readResult.error) {
-											set((current) => ({
-												files: current.files.map((file) =>
-													file.id === targetFile.id
-														? {
-																...file,
-																content: readResult.content,
-																contentLoaded: true,
-															}
-														: file,
-												),
-											}));
-										}
-									} catch (error) {
-										console.error(
-											"Failed to hydrate active file content from workspace:",
-											error,
-										);
-									}
-								}
-
-								set({ activeFileId: targetFile.id });
+							const opened = await get().openFileByPath(meta.activeFilePath);
+							if (!opened) {
+								console.warn(
+									"Failed to restore active file:",
+									meta.activeFilePath,
+								);
 							}
 						}
 					} else {
@@ -1459,7 +1379,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 
 	refreshFileTree: async () => {
 		const state = get();
-		const { activeRepoId, repos, files, activeFileId } = state;
+		const { activeRepoId, repos, files, activeFileId, fileMetaByPath } = state;
 		if (!activeRepoId) return;
 
 		const repo = repos.find((r) => r.id === activeRepoId);
@@ -1469,20 +1389,38 @@ export const useAppStore = create<AppState>((set, get) => ({
 			const result = await window.desktopAPI?.scanDirectory?.(repo.path);
 			if (result) {
 				const nextTree = result.nodes;
-				const nextFiles = reconcileFilesWithTree(nextTree, files);
+				const treePaths = new Set<string>();
+				for (const node of collectFileNodes(nextTree)) {
+					treePaths.add(normalizePathForCompare(node.path));
+				}
+
+				// 已打开文档：移除树中已不存在的条目（打开的 standalone 文件保持原行为，
+				// 与旧 reconcile 语义一致：仅保留树内文件）
+				const nextFiles = files.filter((file) =>
+					treePaths.has(normalizePathForCompare(file.path)),
+				);
+				const nextMeta: Record<string, FileMeta> = {};
+				for (const [pathKey, meta] of Object.entries(fileMetaByPath)) {
+					if (treePaths.has(pathKey)) nextMeta[pathKey] = meta;
+				}
 
 				const previousActivePath = files.find(
 					(f) => f.id === activeFileId,
 				)?.path;
-				const nextActiveFileId = resolveActiveFileId(
-					nextFiles,
-					activeFileId,
-					previousActivePath,
-				);
+				const nextActiveFileId = nextFiles.some((f) => f.id === activeFileId)
+					? activeFileId
+					: previousActivePath
+						? (nextFiles.find(
+								(f) =>
+									normalizePathForCompare(f.path) ===
+									normalizePathForCompare(previousActivePath),
+							)?.id ?? null)
+						: null;
 
 				set({
 					fileTree: nextTree,
 					files: nextFiles,
+					fileMetaByPath: nextMeta,
 					activeFileId: nextActiveFileId,
 				});
 				scheduleSaveAppState();
@@ -1498,6 +1436,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 
 	// ===== 兼容旧代码 =====
 	files: [],
+	fileMetaByPath: {},
 	activeFileId: null,
 	isTracksPanelOpen: false,
 	setTracksPanelOpen: (open) => set({ isTracksPanelOpen: open }),
@@ -2261,49 +2200,74 @@ export const useAppStore = create<AppState>((set, get) => ({
 		});
 	},
 
+	openFileByPath: async (path) => {
+		const normalized = normalizePathForCompare(path);
+		const existing = get().files.find(
+			(file) => normalizePathForCompare(file.path) === normalized,
+		);
+		const targetId = existing?.id ?? path;
+
+		if (existing?.contentLoaded) {
+			set({ activeFileId: targetId });
+			scheduleSaveAppState();
+			return true;
+		}
+
+		try {
+			const readResult = await window.desktopAPI.readFile(path);
+			if (readResult.error) return false;
+			get().addFile({
+				id: targetId,
+				name: basenameFromPath(path),
+				path,
+				content: readResult.content,
+				contentLoaded: true,
+			});
+			return true;
+		} catch (error) {
+			console.error("Failed to open file by path:", error);
+			return false;
+		}
+	},
+
 	addFile: (file) => {
 		set((state) => {
 			const parsedMeta = extractAtDocFileMeta(file.content ?? "");
-			const incomingMetaClass =
-				file.metaClass ??
-				(parsedMeta.metaClass.length > 0 ? parsedMeta.metaClass : undefined);
-			const incomingMetaTags =
-				file.metaTags ??
-				(parsedMeta.metaTags.length > 0 ? parsedMeta.metaTags : undefined);
-			const incomingMetaStatus = file.metaStatus ?? parsedMeta.metaStatus;
-			const incomingMetaTabist = file.metaTabist ?? parsedMeta.metaTabist;
-			const incomingMetaApp = file.metaApp ?? parsedMeta.metaApp;
-			const incomingMetaGithub = file.metaGithub ?? parsedMeta.metaGithub;
-			const incomingMetaLicense = file.metaLicense ?? parsedMeta.metaLicense;
-			const incomingMetaSource = file.metaSource ?? parsedMeta.metaSource;
-			const incomingMetaRelease = file.metaRelease ?? parsedMeta.metaRelease;
-			const incomingMetaAlias =
-				file.metaAlias ??
-				(parsedMeta.metaAlias.length > 0 ? parsedMeta.metaAlias : undefined);
-			const incomingMetaTitle = file.metaTitle ?? parsedMeta.metaTitle;
+			const incomingMeta: FileMeta = {
+				metaClass:
+					parsedMeta.metaClass.length > 0 ? parsedMeta.metaClass : undefined,
+				metaTags:
+					parsedMeta.metaTags.length > 0 ? parsedMeta.metaTags : undefined,
+				metaStatus: parsedMeta.metaStatus,
+				metaTabist: parsedMeta.metaTabist,
+				metaApp: parsedMeta.metaApp,
+				metaGithub: parsedMeta.metaGithub,
+				metaLicense: parsedMeta.metaLicense,
+				metaSource: parsedMeta.metaSource,
+				metaRelease: parsedMeta.metaRelease,
+				metaAlias:
+					parsedMeta.metaAlias.length > 0 ? parsedMeta.metaAlias : undefined,
+				metaTitle: parsedMeta.metaTitle,
+			};
 			const existing = state.files.find((f) => f.path === file.path);
 			if (existing) {
 				const merged = {
 					...existing,
-					// Prefer latest metadata/content when provided
+					// Prefer latest content when provided
 					name: file.name || existing.name,
 					content: file.content ?? existing.content,
-					metaClass: incomingMetaClass ?? existing.metaClass,
-					metaTags: incomingMetaTags ?? existing.metaTags,
-					metaStatus: incomingMetaStatus ?? existing.metaStatus,
-					metaTabist: incomingMetaTabist ?? existing.metaTabist,
-					metaApp: incomingMetaApp ?? existing.metaApp,
-					metaGithub: incomingMetaGithub ?? existing.metaGithub,
-					metaLicense: incomingMetaLicense ?? existing.metaLicense,
-					metaSource: incomingMetaSource ?? existing.metaSource,
-					metaRelease: incomingMetaRelease ?? existing.metaRelease,
-					metaAlias: incomingMetaAlias ?? existing.metaAlias,
-					metaTitle: incomingMetaTitle ?? existing.metaTitle,
-					contentLoaded: file.contentLoaded ?? true,
+					contentLoaded: file.contentLoaded ?? existing.contentLoaded,
 				};
 				return {
 					...state,
 					files: state.files.map((f) => (f.id === existing.id ? merged : f)),
+					fileMetaByPath: {
+						...state.fileMetaByPath,
+						[normalizePathForCompare(file.path)]: {
+							...state.fileMetaByPath[normalizePathForCompare(file.path)],
+							...incomingMeta,
+						},
+					},
 					activeFileId: existing.id,
 				};
 			}
@@ -2313,20 +2277,16 @@ export const useAppStore = create<AppState>((set, get) => ({
 					...state.files,
 					{
 						...file,
-						metaClass: incomingMetaClass,
-						metaTags: incomingMetaTags,
-						metaStatus: incomingMetaStatus,
-						metaTabist: incomingMetaTabist,
-						metaApp: incomingMetaApp,
-						metaGithub: incomingMetaGithub,
-						metaLicense: incomingMetaLicense,
-						metaSource: incomingMetaSource,
-						metaRelease: incomingMetaRelease,
-						metaAlias: incomingMetaAlias,
-						metaTitle: incomingMetaTitle,
 						contentLoaded: file.contentLoaded ?? true,
 					},
 				],
+				fileMetaByPath: {
+					...state.fileMetaByPath,
+					[normalizePathForCompare(file.path)]: {
+						...state.fileMetaByPath[normalizePathForCompare(file.path)],
+						...incomingMeta,
+					},
+				},
 				activeFileId: file.id,
 			};
 		});
@@ -2358,8 +2318,14 @@ export const useAppStore = create<AppState>((set, get) => ({
 				});
 			}
 
+			const nextMeta = { ...state.fileMetaByPath };
+			if (removedPath) {
+				delete nextMeta[removedPath];
+			}
+
 			return {
 				files: newFiles,
+				fileMetaByPath: nextMeta,
 				activeFileId: newActiveId,
 				templateFilePaths: nextTemplatePaths,
 			};
@@ -2433,10 +2399,18 @@ export const useAppStore = create<AppState>((set, get) => ({
 					});
 				}
 
+				const nextMeta = { ...state.fileMetaByPath };
+				const oldMeta = nextMeta[normalizePathForCompare(oldPath)];
+				delete nextMeta[normalizePathForCompare(oldPath)];
+				if (oldMeta) {
+					nextMeta[normalizePathForCompare(newPath)] = oldMeta;
+				}
+
 				return {
 					files: newFiles,
 					activeFileId: newActiveFileId,
 					fileTree: newTree,
+					fileMetaByPath: nextMeta,
 					templateFilePaths: templatePathsChanged
 						? nextTemplatePaths
 						: state.templateFilePaths,
@@ -2457,12 +2431,12 @@ export const useAppStore = create<AppState>((set, get) => ({
 
 	updateFileContent: (id, content) => {
 		const parsedMeta = extractAtDocFileMeta(content);
-		set((state) => ({
-			files: state.files.map((f) =>
-				f.id === id
-					? {
-							...f,
-							content,
+		set((state) => {
+			const target = state.files.find((f) => f.id === id);
+			const nextMeta = target
+				? {
+						...state.fileMetaByPath,
+						[normalizePathForCompare(target.path)]: {
 							metaClass:
 								parsedMeta.metaClass.length > 0
 									? parsedMeta.metaClass
@@ -2483,142 +2457,42 @@ export const useAppStore = create<AppState>((set, get) => ({
 									? parsedMeta.metaAlias
 									: undefined,
 							metaTitle: parsedMeta.metaTitle,
-							contentLoaded: true,
-						}
-					: f,
-			),
-		}));
-	},
-
-	setFileMeta: (
-		id,
-		metaClass,
-		metaTags,
-		metaStatus,
-		metaTabist,
-		metaApp,
-		metaGithub,
-		metaLicense,
-		metaSource,
-		metaRelease,
-		metaAlias,
-		metaTitle,
-	) => {
-		set((state) => {
-			let changed = false;
-			const nextFiles = state.files.map((f) => {
-				if (f.id !== id) return f;
-				const nextClass = metaClass.length > 0 ? [...metaClass] : undefined;
-				const nextTags = metaTags.length > 0 ? [...metaTags] : undefined;
-				const nextStatus = metaStatus;
-				const nextTabist = metaTabist;
-				const nextApp = metaApp;
-				const nextGithub = metaGithub;
-				const nextLicense = metaLicense;
-				const nextSource = metaSource;
-				const nextRelease = metaRelease;
-				const nextAlias =
-					metaAlias && metaAlias.length > 0 ? [...metaAlias] : undefined;
-				const nextTitle = metaTitle;
-				if (
-					isSameStringList(f.metaClass, nextClass) &&
-					isSameStringList(f.metaTags, nextTags) &&
-					f.metaStatus === nextStatus &&
-					f.metaTabist === nextTabist &&
-					f.metaApp === nextApp &&
-					f.metaGithub === nextGithub &&
-					f.metaLicense === nextLicense &&
-					f.metaSource === nextSource &&
-					f.metaRelease === nextRelease &&
-					isSameStringList(f.metaAlias, nextAlias) &&
-					f.metaTitle === nextTitle
-				) {
-					return f;
-				}
-				changed = true;
-				return {
-					...f,
-					metaClass: nextClass,
-					metaTags: nextTags,
-					metaStatus: nextStatus,
-					metaTabist: nextTabist,
-					metaApp: nextApp,
-					metaGithub: nextGithub,
-					metaLicense: nextLicense,
-					metaSource: nextSource,
-					metaRelease: nextRelease,
-					metaAlias: nextAlias,
-					metaTitle: nextTitle,
-				};
-			});
-			if (!changed) return state;
-			return { ...state, files: nextFiles };
+						},
+					}
+				: state.fileMetaByPath;
+			return {
+				files: state.files.map((f) =>
+					f.id === id ? { ...f, content, contentLoaded: true } : f,
+				),
+				fileMetaByPath: nextMeta,
+			};
 		});
 	},
 
-	setFileMetaByPath: (
-		path,
-		metaClass,
-		metaTags,
-		metaStatus,
-		metaTabist,
-		metaApp,
-		metaGithub,
-		metaLicense,
-		metaSource,
-		metaRelease,
-		metaAlias,
-		metaTitle,
-	) => {
+	setFileMetaByPath: (path, meta) => {
 		set((state) => {
-			let changed = false;
-			const nextFiles = state.files.map((f) => {
-				if (f.path !== path) return f;
-				const nextClass = metaClass.length > 0 ? [...metaClass] : undefined;
-				const nextTags = metaTags.length > 0 ? [...metaTags] : undefined;
-				const nextStatus = metaStatus;
-				const nextTabist = metaTabist;
-				const nextApp = metaApp;
-				const nextGithub = metaGithub;
-				const nextLicense = metaLicense;
-				const nextSource = metaSource;
-				const nextRelease = metaRelease;
-				const nextAlias =
-					metaAlias && metaAlias.length > 0 ? [...metaAlias] : undefined;
-				const nextTitle = metaTitle;
-				if (
-					isSameStringList(f.metaClass, nextClass) &&
-					isSameStringList(f.metaTags, nextTags) &&
-					f.metaStatus === nextStatus &&
-					f.metaTabist === nextTabist &&
-					f.metaApp === nextApp &&
-					f.metaGithub === nextGithub &&
-					f.metaLicense === nextLicense &&
-					f.metaSource === nextSource &&
-					f.metaRelease === nextRelease &&
-					isSameStringList(f.metaAlias, nextAlias) &&
-					f.metaTitle === nextTitle
-				) {
-					return f;
-				}
-				changed = true;
-				return {
-					...f,
-					metaClass: nextClass,
-					metaTags: nextTags,
-					metaStatus: nextStatus,
-					metaTabist: nextTabist,
-					metaApp: nextApp,
-					metaGithub: nextGithub,
-					metaLicense: nextLicense,
-					metaSource: nextSource,
-					metaRelease: nextRelease,
-					metaAlias: nextAlias,
-					metaTitle: nextTitle,
-				};
-			});
-			if (!changed) return state;
-			return { ...state, files: nextFiles };
+			const key = normalizePathForCompare(path);
+			const existing = state.fileMetaByPath[key];
+			const merged: FileMeta = {
+				metaClass: meta.metaClass?.length
+					? [...meta.metaClass]
+					: existing?.metaClass,
+				metaTags: meta.metaTags?.length
+					? [...meta.metaTags]
+					: existing?.metaTags,
+				metaStatus: meta.metaStatus ?? existing?.metaStatus,
+				metaTabist: meta.metaTabist ?? existing?.metaTabist,
+				metaApp: meta.metaApp ?? existing?.metaApp,
+				metaGithub: meta.metaGithub ?? existing?.metaGithub,
+				metaLicense: meta.metaLicense ?? existing?.metaLicense,
+				metaSource: meta.metaSource ?? existing?.metaSource,
+				metaRelease: meta.metaRelease ?? existing?.metaRelease,
+				metaAlias: meta.metaAlias?.length
+					? [...meta.metaAlias]
+					: existing?.metaAlias,
+				metaTitle: meta.metaTitle ?? existing?.metaTitle,
+			};
+			return { fileMetaByPath: { ...state.fileMetaByPath, [key]: merged } };
 		});
 	},
 
@@ -2798,37 +2672,12 @@ export const useAppStore = create<AppState>((set, get) => ({
 			) {
 				const existingWorkspace = await loadWorkspaceMetadata(targetRepo.path);
 				if (!existingWorkspace?.activeFilePath) {
-					const normalizedPath = normalizePathForCompare(legacyActiveFilePath);
-					const targetFile = get().files.find(
-						(file) => normalizePathForCompare(file.path) === normalizedPath,
-					);
-
-					if (targetFile) {
-						if (!targetFile.contentLoaded) {
-							try {
-								const readResult = await window.desktopAPI.readFile(
-									targetFile.path,
-								);
-								if (!readResult.error) {
-									set((current) => ({
-										files: current.files.map((file) =>
-											file.id === targetFile.id
-												? {
-														...file,
-														content: readResult.content,
-														contentLoaded: true,
-													}
-												: file,
-										),
-									}));
-								}
-							} catch (error) {
-								console.error("legacy active file migration failed:", error);
-							}
-						}
-
-						set({ activeFileId: targetFile.id });
-						scheduleSaveAppState();
+					const opened = await get().openFileByPath(legacyActiveFilePath);
+					if (!opened) {
+						console.warn(
+							"Failed to restore legacy active file:",
+							legacyActiveFilePath,
+						);
 					}
 				}
 			}
@@ -2865,83 +2714,8 @@ void (async () => {
 	}
 })();
 
-// 辅助函数：将 FileNode 树扁平化为 FileItem 数组
-function flattenFileNodes(nodes: FileNode[]): FileItem[] {
-	const result: FileItem[] = [];
-	for (const node of nodes) {
-		if (node.type === "file") {
-			result.push({
-				id: node.id,
-				name: node.name,
-				path: node.path,
-				content: node.content || "",
-				contentLoaded: typeof node.content === "string",
-			});
-		} else if (node.children) {
-			result.push(...flattenFileNodes(node.children));
-		}
-	}
-	return result;
-}
-
 function normalizePathForCompare(p: string): string {
 	return p.replace(/\\/g, "/");
-}
-
-function reconcileFilesWithTree(
-	nodes: FileNode[],
-	currentFiles: FileItem[],
-): FileItem[] {
-	const scanned = flattenFileNodes(nodes);
-	const byPath = new Map(
-		currentFiles.map((f) => [normalizePathForCompare(f.path), f]),
-	);
-
-	return scanned.map((next) => {
-		const existing = byPath.get(normalizePathForCompare(next.path));
-		if (!existing) return next;
-
-		return {
-			...next,
-			id: existing.id ?? next.id,
-			content: existing.content ?? next.content,
-			metaClass: existing.metaClass,
-			metaTags: existing.metaTags,
-			metaStatus: existing.metaStatus,
-			metaTabist: existing.metaTabist,
-			metaApp: existing.metaApp,
-			metaGithub: existing.metaGithub,
-			metaLicense: existing.metaLicense,
-			metaSource: existing.metaSource,
-			metaRelease: existing.metaRelease,
-			metaAlias: existing.metaAlias,
-			metaTitle: existing.metaTitle,
-			contentLoaded: existing.contentLoaded ?? next.contentLoaded,
-		};
-	});
-}
-
-function resolveActiveFileId(
-	nextFiles: FileItem[],
-	currentActiveId: string | null,
-	previousActivePath?: string,
-): string | null {
-	if (!currentActiveId) return null;
-
-	if (nextFiles.some((f) => f.id === currentActiveId)) {
-		return currentActiveId;
-	}
-
-	if (previousActivePath) {
-		const byPath = nextFiles.find(
-			(f) =>
-				normalizePathForCompare(f.path) ===
-				normalizePathForCompare(previousActivePath),
-		);
-		if (byPath) return byPath.id;
-	}
-
-	return null;
 }
 
 function basenameFromPath(p: string): string {

--- a/src/renderer/types/repo.ts
+++ b/src/renderer/types/repo.ts
@@ -95,6 +95,31 @@ export interface FileNode {
 }
 
 /**
+ * 树节点的 ATDOC 元数据缓存（从文件内容解析，独立于打开的文档集合）。
+ * key 为 normalized path。
+ */
+export interface FileMeta {
+	metaClass?: string[];
+	metaTags?: string[];
+	metaStatus?: "draft" | "active" | "done" | "released";
+	metaTabist?: string;
+	metaApp?: string;
+	metaGithub?: string;
+	metaLicense?:
+		| "CC0-1.0"
+		| "CC-BY-4.0"
+		| "CC-BY-SA-4.0"
+		| "CC-BY-NC-4.0"
+		| "CC-BY-NC-SA-4.0"
+		| "CC-BY-ND-4.0"
+		| "CC-BY-NC-ND-4.0";
+	metaSource?: string;
+	metaRelease?: string;
+	metaAlias?: string[];
+	metaTitle?: string;
+}
+
+/**
  * 用户删除偏好设置
  */
 export type DeleteBehavior = "system-trash" | "repo-trash" | "ask-every-time";


### PR DESCRIPTION
## Summary

Implements the first half of #140: removes the dual file representation (`fileTree` + flat `files` copy) in the renderer store.

**Before**: `switchRepo` and `refreshFileTree` rebuilt `files` by flattening the whole tree (`flattenFileNodes` / `reconcileFilesWithTree`), keeping two sources of truth for the same data and a deprecated `FileItem` model with 12 embedded ATDOC meta fields.

**After**:
- `files: FileItem[]` = **opened documents only** (tab semantics), maintained by `addFile`/`removeFile`/`renameFile`/`setActiveFile`. `FileItem` is trimmed to `{id, name, path, content, contentLoaded}`.
- New `fileMetaByPath: Record<normalizedPath, FileMeta>` = tree-node ATDOC meta cache (tags/status/title/...). Populated on open (from content), on edit (`updateFileContent` re-parses), and by the existing Sidebar background reader task (which now writes per-path meta instead of into opened files).
- `switchRepo` no longer flattens; the active file is restored through the new `openFileByPath` action (read → upsert → activate), also used for legacy session restore in `initialize`.
- `refreshFileTree` only prunes opened docs/meta whose paths disappeared from the scanned tree — the active file stays stable across refreshes, no full rebuild.
- `removeFile`/`renameFile` clean up / migrate meta keys.
- Deleted: `flattenFileNodes`, `reconcileFilesWithTree`, `resolveActiveFileId`.

## Consumers migrated

- FileTreeItem, Sidebar (filters + background meta task), App (template picker candidates now collected from the tree with `collectFileNodes`; template content resolved per-path), QuickFileSwitcher (meta via `fileMetaByPath`, candidates still from the tree), TemplatesPage.
- New shared `lib/file-tree-utils.ts` (collectFileNodes / collectFilePaths).

## Tests

New store-level suite (`appStore.fileMeta.test.ts`, 6 cases): meta parsing on addFile, meta refresh on content change, merge semantics, cleanup on remove, key migration on rename, and the refresh contract. Full suite: 192 renderer tests, `pnpm check` clean, web build clean.

## Live verification (dev instance via MCP)

- Tree renders normally (134 nodes); tags/status badges render from `fileMetaByPath` (background task fills them without any opened files).
- After app restart the previously active file is restored and hydrated through `openFileByPath`.
- After a watcher-triggered tree refresh the open document stays open (content intact).

## Notes

- Behavior parity note: previously `refreshFileTree` silently dropped standalone files (outside the repo) from `files`; the new prune keeps that same semantic for opened docs.
- `#140` store-splitting (multi-store) is intentionally out of scope for this PR.