### PR TITLE
fix(audio): 正式版 SoundFont 加载失败（Tauri 嵌入资源 MIME 回退 text/html）

### DIFF
--- a/src/renderer/lib/assets.test.ts
+++ b/src/renderer/lib/assets.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { loadSoundFontFromUrl } from "./assets";
+
+function buildSoundFontBytes(size = 4096): Uint8Array {
+	const bytes = new Uint8Array(size);
+	bytes.set([0x52, 0x49, 0x46, 0x46], 0); // RIFF
+	bytes.set([0x73, 0x66, 0x62, 0x6b], 8); // sfbk
+	return bytes;
+}
+
+function buildHtmlBytes(): Uint8Array {
+	return new TextEncoder().encode(
+		"<!doctype html><html><head><title>404 Not Found</title></head><body>not found</body></html>",
+	);
+}
+
+interface MockFetchOptions {
+	contentType: string;
+	payload: Uint8Array;
+}
+
+function mockFetchOnce(options: MockFetchOptions): void {
+	vi.stubGlobal(
+		"fetch",
+		vi.fn().mockResolvedValue({
+			ok: true,
+			headers: {
+				get: (name: string) =>
+					name.toLowerCase() === "content-type" ? options.contentType : null,
+			},
+			arrayBuffer: async () => options.payload.buffer,
+		}),
+	);
+}
+
+function createMockApi(): { loadSoundFont: ReturnType<typeof vi.fn> } {
+	return { loadSoundFont: vi.fn() };
+}
+
+describe("loadSoundFontFromUrl", () => {
+	beforeEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("accepts a valid soundfont when the server reports text/html (Tauri embedded assets)", async () => {
+		mockFetchOnce({ contentType: "text/html", payload: buildSoundFontBytes() });
+		const api = createMockApi();
+
+		const ok = await loadSoundFontFromUrl(
+			api as never,
+			"tauri://localhost/assets/sound.sf2",
+		);
+
+		expect(ok).toBe(true);
+		expect(api.loadSoundFont).toHaveBeenCalledOnce();
+	});
+
+	it("rejects text/html content that is not a soundfont payload", async () => {
+		mockFetchOnce({ contentType: "text/html", payload: buildHtmlBytes() });
+		const api = createMockApi();
+
+		const ok = await loadSoundFontFromUrl(
+			api as never,
+			"tauri://localhost/assets/missing.sf2",
+		);
+
+		expect(ok).toBe(false);
+		expect(api.loadSoundFont).not.toHaveBeenCalled();
+	});
+
+	it("accepts a valid soundfont with a proper binary content type", async () => {
+		mockFetchOnce({
+			contentType: "application/octet-stream",
+			payload: buildSoundFontBytes(),
+		});
+		const api = createMockApi();
+
+		const ok = await loadSoundFontFromUrl(
+			api as never,
+			"https://example.com/assets/sonivox.sf3",
+		);
+
+		expect(ok).toBe(true);
+		expect(api.loadSoundFont).toHaveBeenCalledOnce();
+	});
+
+	it("rejects payloads that are neither soundfont nor HTML", async () => {
+		mockFetchOnce({
+			contentType: "application/octet-stream",
+			payload: new Uint8Array(64),
+		});
+		const api = createMockApi();
+
+		const ok = await loadSoundFontFromUrl(
+			api as never,
+			"https://example.com/assets/data.bin",
+		);
+
+		expect(ok).toBe(false);
+		expect(api.loadSoundFont).not.toHaveBeenCalled();
+	});
+
+	it("returns false when the fetch response is not ok", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue({ ok: false, status: 404 }),
+		);
+		const api = createMockApi();
+
+		const ok = await loadSoundFontFromUrl(
+			api as never,
+			"https://example.com/missing.sf2",
+		);
+
+		expect(ok).toBe(false);
+		expect(api.loadSoundFont).not.toHaveBeenCalled();
+	});
+});

--- a/src/renderer/lib/assets.ts
+++ b/src/renderer/lib/assets.ts
@@ -164,17 +164,22 @@ async function loadSoundFontFromUrlInner(
 			return false;
 		}
 
+		const buffer = await response.arrayBuffer();
+		const u8 = new Uint8Array(buffer);
+
+		// Tauri 的嵌入资源协议（tauri:// 与 asset://）对 mime_guess 无法识别的
+		// 扩展名（如 .sf2/.sf3）会回退为 text/html。这里以内容魔数（RIFF/sfbk）
+		// 为准：只有"既不是 HTML 页面、也不是合法 soundfont"的响应才拒绝。
 		const contentType =
 			response.headers.get("content-type")?.toLowerCase() ?? "";
-		if (contentType.includes("text/html")) {
+		if (contentType.includes("text/html") && !isLikelySoundFont(u8)) {
+			const preview = toAscii(u8, 0, Math.min(64, u8.length));
 			console.warn(
-				`[AssetLoader] Soundfont URL returned HTML content: ${soundFontUrl}`,
+				`[AssetLoader] Soundfont URL returned non-soundfont HTML content: ${soundFontUrl}; header="${preview}"`,
 			);
 			return false;
 		}
 
-		const buffer = await response.arrayBuffer();
-		const u8 = new Uint8Array(buffer);
 		if (!isLikelySoundFont(u8)) {
 			const preview = toAscii(u8, 0, Math.min(16, u8.length));
 			console.warn(


### PR DESCRIPTION
## 问题

开发版（vite dev server）能正常播放，正式版（release 构建）播放无声。

## 根因

Tauri 嵌入资源协议（`tauri://` 生产页面、`asset://` 外部 SoundFont）对 `mime_guess` 无法识别的扩展名（`.sf2`/`.sf3`）会回退为 `text/html` Content-Type。`loadSoundFontFromUrl` 里 `contentType.includes("text/html")` 的防御检查直接拒绝了这类响应，导致 SoundFont 永远加载不上 → alphaTab 无音频 → 播放无声。vite dev server 返回正确 MIME，所以开发版正常。

实测（生产环境 `tauri://localhost`，31MB GeneralUser-GS.sf2）：fetch 本身完整成功（32,319,396 字节，RIFF/sfbk 魔数正确），仅 Content-Type 为 text/html。

## 修复

`src/renderer/lib/assets.ts`：以内容魔数（RIFF/sfbk）为准 —— 只有"既不是 HTML 页面、也不是合法 SoundFont"的响应才拒绝；合法 SoundFont 即使 Content-Type 是 text/html 也放行。

## 验证

- 新增 `assets.test.ts` 5 例：text/html + 合法 SF → 成功；text/html + HTML → 拒绝；正常 MIME + 合法 SF → 成功；非 SF 载荷 → 拒绝；fetch 非 2xx → 拒绝
- `pnpm check` 通过，213 个测试全部通过
- 本机用 `tauri build --debug`（生产资源 + debug 二进制）实测：SoundFont 加载成功，`api.play()` didPlay:true，播放状态 running