### PR TITLE
test: fix flaky delete-scope test on macOS

### DIFF
--- a/src-tauri/src/support.rs
+++ b/src-tauri/src/support.rs
@@ -567,7 +567,12 @@ pub(crate) mod test_helpers {
             now_ms()
         ));
         fs::create_dir_all(&dir).expect("failed to create temp test directory");
-        dir
+        // Resolve symlinks and macOS firmlinks (e.g. /var -> /private/var)
+        // once, up front. Later fs::canonicalize calls on freshly created files
+        // inside this directory then run against the already-resolved path,
+        // avoiding intermittent ENOENT from realpath racing the firmlink
+        // boundary during path-authorization checks.
+        fs::canonicalize(&dir).unwrap_or(dir)
     }
 
     pub(crate) fn env_lock() -> &'static Mutex<()> {


### PR DESCRIPTION
## Problem

`delete_file_repo_trash_rejects_paths_outside_the_repo_root` flakes on macOS CI with a ~50% failure rate. The test writes a file under $TMPDIR and immediately calls `delete_file`, which runs `fs::canonicalize` on that path. On macOS, $TMPDIR lives under `/var/folders`, where `/var` is a firmlink into `/private/var`; realpath intermittently returns ENOENT for the freshly created file while racing the firmlink boundary.

## Fix

`temp_dir_for` now resolves the temp directory to its canonical path once at creation time, so later `fs::canonicalize` calls on files inside it run against the already-resolved `/private/var/...` path and no longer race the firmlink.

## Validation

- `cargo test` compiles cleanly (local Windows test binary has an unrelated STATUS_ENTRYPOINT_NOT_FOUND runtime issue).
- macOS CI Desktop Build is the authoritative check.